### PR TITLE
Replaced relative import paths to enhance usability on github.

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,10 +9,11 @@ import (
 	"os"
 	"strings"
 	"time"
-	"zgrab/zlib"
-	"ztools/processing"
-	"ztools/zlog"
-	"ztools/ztls"
+
+	"github.com/zmap/zgrab/zlib"
+	"github.com/zmap/ztools/processing"
+	"github.com/zmap/ztools/zlog"
+	"github.com/zmap/ztools/ztls"
 )
 
 // Command-line flags

--- a/zlib/config.go
+++ b/zlib/config.go
@@ -3,7 +3,8 @@ package zlib
 import (
 	"crypto/x509"
 	"time"
-	"ztools/zlog"
+
+	"github.com/zmap/ztools/zlog"
 )
 
 type Config struct {

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"time"
 
-	"ztools/ztls"
+	"github.com/zmap/ztools/ztls"
 )
 
 var smtpEndRegex = regexp.MustCompile(`(?:\r\n)|^[0-9]{3} .+\r\n$`)

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -9,7 +9,8 @@ import (
 	"net"
 	"strconv"
 	"time"
-	"ztools/processing"
+
+	"github.com/zmap/ztools/processing"
 )
 
 type GrabTarget struct {

--- a/zlib/heartbleed_event.go
+++ b/zlib/heartbleed_event.go
@@ -2,7 +2,8 @@ package zlib
 
 import (
 	"encoding/json"
-	"ztools/ztls"
+
+	"github.com/zmap/ztools/ztls"
 )
 
 type HeartbleedEvent struct {

--- a/zlib/processing.go
+++ b/zlib/processing.go
@@ -1,6 +1,6 @@
 package zlib
 
-import "ztools/processing"
+import "github.com/zmap/ztools/processing"
 
 // GrabWorker implements ztools.processing.Worker
 type GrabWorker struct {

--- a/zlib/ztls_event.go
+++ b/zlib/ztls_event.go
@@ -2,7 +2,8 @@ package zlib
 
 import (
 	"encoding/json"
-	"ztools/ztls"
+
+	"github.com/zmap/ztools/ztls"
 )
 
 // HandshakeEvent implements the EventData interface


### PR DESCRIPTION
Hi,

at first I want to thank you guys for creating this amazing toolchain! 

I made this change because I tried to use zgrab and ran into the following error:

```
$ go get github.com/zmap/zgrab
package github.com/zmap/zgrab
        imports zgrab/zlib: unrecognized import path "zgrab/zlib"
package github.com/zmap/zgrab
        imports ztools/processing: unrecognized import path "ztools/processing"
package github.com/zmap/zgrab
        imports ztools/zlog: unrecognized import path "ztools/zlog"
package github.com/zmap/zgrab
        imports ztools/ztls: unrecognized import path "ztools/ztls"
```

Then I read the README (that's what I should have done first ;)) and did the steps to successfully build zgrab, which was more complicated than a usual go-build for github projects.

```
$ cd $GOPATH/src
$ git clone https://github.com/zmap/zgrab.git
$ git clone https://github.com/zmap/ztools.git
$ cd zgrab && go build
```

So, with this change, you can remove the following line from the README:

```
Unfortunately, since zgrab is still actively under development, you will also need to clone the ztools repository to $GOPATH/src/ztools.
```

since it's not necessary anymore. With a `go get github.com/zmap/zgrab` all needed tools go to `$GOPATH/src/github.com/zmap/*`.

If there is another reason for local imports, which I'm not aware of, just ignore this pull request.

Regards,
Malte
