### PR TITLE
Extract String() method from MarshalJSON [fixed]

### DIFF
--- a/ztools/ztls/ztls_json.go
+++ b/ztools/ztls/ztls_json.go
@@ -53,32 +53,14 @@ func (cs CipherSuite) MarshalJSON() ([]byte, error) {
 	enc := strings.ToUpper(hex.EncodeToString(buf))
 	m := make(map[string]interface{}, 3)
 	m["hex"] = fmt.Sprintf("0x%s", enc)
-	num := int(cs)
-	if name, ok := cipherSuiteNames[num]; ok {
-		m["name"] = name
-	} else {
-		m["name"] = "unknown"
-	}
-	m["value"] = num
+	m["name"] = cs.String()
+	m["value"] = int(cs)
 	return json.Marshal(m)
 }
 
 func (v TLSVersion) MarshalJSON() ([]byte, error) {
-	var name string
-	switch v {
-	case 768:
-		name = "SSLv3"
-	case 769:
-		name = "TLSv1.0"
-	case 770:
-		name = "TLSv1.1"
-	case 771:
-		name = "TLSv1.2"
-	default:
-		name = "unknown"
-	}
 	m := make(map[string]interface{})
-	m["name"] = name
+	m["name"] = v.String()
 	m["value"] = int(v)
 	return json.Marshal(m)
 }

--- a/ztools/ztls/ztls_names.go
+++ b/ztools/ztls/ztls_names.go
@@ -357,3 +357,25 @@ func init() {
 	cipherSuiteNames[0xFF85] = "OP_PCL_TLS10_AES_128_CBC_SHA512"
 }
 
+func (cs CipherSuite) String() string {
+	if name, ok := cipherSuiteNames[int(cs)]; ok {
+		return name
+	} else {
+		return "unknown"
+	}
+}
+
+func (v TLSVersion) String() string {
+	switch v {
+	case 0x0300:
+		return "SSLv3"
+	case 0x0301:
+		return "TLSv1.0"
+	case 0x0302:
+		return "TLSv1.1"
+	case 0x0303:
+		return "TLSv1.2"
+	default:
+		return "unknown"
+	}
+}


### PR DESCRIPTION
This makes it possible to retrieve the name without marshalling the struct to JSON.

`x.String()` works better than `string(x)`