### PR TITLE
Gracefully handle negative serial numbers

### DIFF
--- a/ztools/x509/x509.go
+++ b/ztools/x509/x509.go
@@ -933,11 +933,6 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 	}
 
 	out.PublicKeyAlgorithmOID = in.TBSCertificate.PublicKey.Algorithm.Algorithm
-
-	if in.TBSCertificate.SerialNumber.Sign() < 0 {
-		return nil, errors.New("x509: negative serial number")
-	}
-
 	out.Version = in.TBSCertificate.Version + 1
 	out.SerialNumber = in.TBSCertificate.SerialNumber
 


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc5280#section-4.1.2.2
```
Non-conforming CAs may issue certificates with serial numbers
that are negative or zero.  Certificate users SHOULD be prepared to
gracefully handle such certificates.
```
This issue is also addressed by https://github.com/golang/go/issues/8265

From 208314 hosts 662 were affected by this problem. Some examples:
* 93.57.50.24
* 123.100.249.85
* 202.43.34.79