### PR TITLE
Provide more validation errors

### DIFF
--- a/ztools/x509/json.go
+++ b/ztools/x509/json.go
@@ -89,11 +89,11 @@ type jsonTBSCertificate struct {
 }
 
 type jsonSignature struct {
-	Value           []byte `json:"value"`
-	Valid           bool   `json:"valid"`
-	ValidationError string `json:"validation_error,omitempty"`
-	Matches         *bool  `json:"matches_domain"`
-	SelfSigned      bool   `json:"self_signed"`
+	Value            []byte   `json:"value"`
+	Valid            bool     `json:"valid"`
+	ValidationErrors []string `json:"validation_errors"`
+	Matches          *bool    `json:"matches_domain"`
+	SelfSigned       bool     `json:"self_signed"`
 }
 
 type jsonCertificate struct {
@@ -162,8 +162,12 @@ func (c *Certificate) MarshalJSON() ([]byte, error) {
 	jc.SignatureAlgorithm = algorithm
 	jc.Signature.Value = c.Signature
 	jc.Signature.Valid = c.valid
-	if c.validationError != nil {
-		jc.Signature.ValidationError = c.validationError.Error()
+	if len(c.validationErrors) > 0 {
+		errors := make([]string, len(c.validationErrors))
+		for i, err := range c.validationErrors {
+			errors[i] = err.Error()
+		}
+		jc.Signature.ValidationErrors = errors
 	}
 	if c.Subject.CommonName == c.Issuer.CommonName {
 		jc.Signature.SelfSigned = true

--- a/ztools/x509/x509.go
+++ b/ztools/x509/x509.go
@@ -562,9 +562,9 @@ type Certificate struct {
 	FingerprintSHA256 CertificateFingerprint
 
 	// Internal
-	valid           bool
-	validationError error
-	matchesDomain   *bool
+	valid            bool
+	validationErrors []error
+	matchesDomain    *bool
 }
 
 // ErrUnsupportedAlgorithm results from attempting to perform an operation that

--- a/ztools/ztls/handshake_client.go
+++ b/ztools/ztls/handshake_client.go
@@ -268,15 +268,14 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 			}
 			opts.Intermediates.AddCert(cert)
 		}
-		c.verifiedChains, err = certs[0].Verify(opts)
+		var errors []error
+		c.verifiedChains, errors = certs[0].Verify(opts)
 		c.handshakeLog.ServerCertificates.ParsedCertificates = certs
 
 		// If actually verifying and invalid, reject
-		if !c.config.InsecureSkipVerify {
-			if err != nil {
-				c.sendAlert(alertBadCertificate)
-				return err
-			}
+		if !c.config.InsecureSkipVerify && len(errors) > 0 {
+			c.sendAlert(alertBadCertificate)
+			return errors[0]
 		}
 	}
 

--- a/ztools/ztls/handshake_server.go
+++ b/ztools/ztls/handshake_server.go
@@ -585,10 +585,10 @@ func (hs *serverHandshakeState) processCertsFromClient(certificates [][]byte) (c
 			opts.Intermediates.AddCert(cert)
 		}
 
-		chains, err := certs[0].Verify(opts)
-		if err != nil {
+		chains, errs := certs[0].Verify(opts)
+		if len(errs) > 0 {
 			c.sendAlert(alertBadCertificate)
-			return nil, errors.New("tls: failed to verify client's certificate: " + err.Error())
+			return nil, errors.New("tls: failed to verify client's certificate: " + errs[0].Error())
 		}
 
 		ok := false


### PR DESCRIPTION
This pull request is not intended to be merged (yet).

A certificate might be invalid for several reaons. I think it is useful to get to know them all.
My pull request modifies the validation methods to return multiple errors instead of only the first one.
It would also be nice to get messages that are easier to parse. How could we achieve that?
