### PR TITLE
Add coveralls.io to display test coverage

### DIFF
--- a/.test-cover.sh
+++ b/.test-cover.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Issue:  https://github.com/mattn/goveralls/issues/20
+# Source: https://github.com/uber/go-torch/blob/63da5d33a225c195fea84610e2456d5f722f3963/.test-cover.sh
+
+echo "mode: set" > acc.out
+FAIL=0
+
+# Standard go tooling behavior is to ignore dirs with leading underscors
+for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -type d);
+do
+  if ls $dir/*.go &> /dev/null; then
+    go test -v -coverprofile=profile.out $dir || FAIL=$?
+    if [ -f profile.out ]
+    then
+      cat profile.out | grep -v "mode: set" | grep -v "mocks.go" >> acc.out
+      rm profile.out
+    fi
+  fi
+done
+
+# Failures have incomplete results, so don't send
+if [ "$FAIL" -eq 0 ]; then
+  goveralls -service=travis-ci -v -coverprofile=acc.out
+fi
+
+rm -f acc.out
+
+exit $FAIL

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,26 @@
 language: go
 go:
-- 1.4
-env:
-  global:
-  - GOPATH="$HOME/gopath"
-before_script:
-- mkdir -p $HOME/gopath/src/github.com/zmap
-- ln -s $TRAVIS_BUILD_DIR $HOME/gopath/src/github.com/zmap/ || true
+- 1.4.2
+before_install:
 - go get gopkg.in/check.v1
 - go get github.com/dadrian/rc2
+- go get github.com/axw/gocov/gocov
+- go get github.com/modocache/gover
+- go get github.com/mattn/goveralls
+- go get golang.org/x/tools/cmd/cover
+before_script:
+- mkdir -p $GOPATH/src/github.com/zmap
+- ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/zmap/ || true
 script:
-- go test -v ./...
+# Unfortunately we have to test each package manually
+# https://github.com/mattn/goveralls/issues/20#issuecomment-72758697
+- go test -v -coverprofile=keys.coverprofile      ./ztools/keys
+- go test -v -coverprofile=x509.coverprofile      ./ztools/x509
+- go test -v -coverprofile=x509.pkix.coverprofile ./ztools/x509/pkix
+- go test -v -coverprofile=zlog.coverprofile      ./ztools/zlog
+- go test -v -coverprofile=ztls.coverprofile      ./ztools/ztls
+- $GOPATH/bin/gover
+- $GOPATH/bin/goveralls -coverprofile=gover.coverprofile -service travis-ci
 notifications:
   email:
   - zmap-devel@umich.edu

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,13 @@ before_install:
 - go get gopkg.in/check.v1
 - go get github.com/dadrian/rc2
 - go get github.com/axw/gocov/gocov
-- go get github.com/modocache/gover
 - go get github.com/mattn/goveralls
 - go get golang.org/x/tools/cmd/cover
 before_script:
 - mkdir -p $GOPATH/src/github.com/zmap
 - ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/zmap/ || true
 script:
-# Unfortunately we have to test each package manually
-# https://github.com/mattn/goveralls/issues/20#issuecomment-72758697
-- go test -v -coverprofile=keys.coverprofile      ./ztools/keys
-- go test -v -coverprofile=x509.coverprofile      ./ztools/x509
-- go test -v -coverprofile=x509.pkix.coverprofile ./ztools/x509/pkix
-- go test -v -coverprofile=zlog.coverprofile      ./ztools/zlog
-- go test -v -coverprofile=ztls.coverprofile      ./ztools/ztls
-- $GOPATH/bin/gover
-- $GOPATH/bin/goveralls -coverprofile=gover.coverprofile -service travis-ci
+- ./.test-cover.sh
 notifications:
   email:
   - zmap-devel@umich.edu

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ zgrab
 ==================
 
 [![Build Status](https://travis-ci.org/zmap/zgrab.svg?branch=master)](https://travis-ci.org/zmap/zgrab)
+[![Coverage Status](https://coveralls.io/repos/zmap/zgrab/badge.svg?branch=master&service=github)](https://coveralls.io/github/zmap/zgrab?branch=master)
 
 A TLS Banner Grabber, in Go
 


### PR DESCRIPTION
This pull request also updates Go from 1.4 to 1.4.2.
You need to connect your github Account with Coveralls.io.
The result looks like this: https://coveralls.io/github/corny/zgrab