### PR TITLE
Zzma/follow redirects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ zgrab
 
 # Mac OS X files
 .DS_Store
+
+# Project files
+*.iml
+.idea

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func init() {
 	flag.StringVar(&config.HTTP.UserAgent, "http-user-agent", "", "Set a custom HTTP user agent")
 	flag.StringVar(&config.HTTP.ProxyDomain, "http-proxy-domain", "", "Send a CONNECT <domain> first")
 	flag.IntVar(&config.HTTP.MaxSize, "http-max-size", 256, "Max kilobytes to read in response to an HTTP request")
+	flag.IntVar(&config.HTTP.MaxRedirects, "http-max-redirects", 0, "Max number of redirects to follow")
 	flag.BoolVar(&config.TLSExtendedRandom, "tls-extended-random", false, "send extended random extension")
 
 	flag.StringVar(&config.EHLODomain, "ehlo", "", "Send an EHLO with the specified domain (implies --smtp)")

--- a/zlib/config.go
+++ b/zlib/config.go
@@ -27,11 +27,12 @@ import (
 )
 
 type HTTPConfig struct {
-	Method      string
-	Endpoint    string
-	UserAgent   string
-	ProxyDomain string
-	MaxSize     int
+	Method      	string
+	Endpoint    	string
+	UserAgent   	string
+	ProxyDomain 	string
+	MaxSize     	int
+	MaxRedirects 	int
 }
 
 type SSHScanConfig struct {

--- a/zlib/config.go
+++ b/zlib/config.go
@@ -27,12 +27,12 @@ import (
 )
 
 type HTTPConfig struct {
-	Method      	string
-	Endpoint    	string
-	UserAgent   	string
-	ProxyDomain 	string
-	MaxSize     	int
-	MaxRedirects 	int
+	Method       string
+	Endpoint     string
+	UserAgent    string
+	ProxyDomain  string
+	MaxSize      int
+	MaxRedirects int
 }
 
 type SSHScanConfig struct {

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -32,7 +32,9 @@ import (
 	"github.com/zmap/zgrab/ztools/ssh"
 	"github.com/zmap/zgrab/ztools/util"
 	"github.com/zmap/zgrab/ztools/x509"
+	"github.com/zmap/zgrab/ztools/zlog"
 	"github.com/zmap/zgrab/ztools/ztls"
+	"io"
 )
 
 var smtpEndRegex = regexp.MustCompile(`(?:^\d\d\d\s.*\r\n$)|(?:^\d\d\d-[\s\S]*\r\n\d\d\d\s.*\r\n$)`)
@@ -352,6 +354,9 @@ func (c *Conn) doHTTP(config *HTTPConfig) error {
 			}
 
 			if httpResponse, err = c.sendHTTPRequestReadHTTPResponse(redirectBaseRequest, config); err != nil {
+				if err == io.ErrUnexpectedEOF {
+					zlog.Errorf("Connection closed before making redirect to %s (%s)", c.domain, c.RemoteAddr())
+				}
 				return err
 			}
 

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -48,20 +48,20 @@ const (
 // Implements the net.Conn interface
 type Conn struct {
 	// Underlying network connection
-	conn    net.Conn
-	tlsConn *ztls.Conn
-	isTls   bool
+	conn                net.Conn
+	tlsConn             *ztls.Conn
+	isTls               bool
 
-	grabData GrabData
+	grabData            GrabData
 
 	// Max TLS version
-	maxTlsVersion uint16
+	maxTlsVersion       uint16
 
 	// Cache the deadlines so we can reapply after TLS handshake
-	readDeadline  time.Time
-	writeDeadline time.Time
+	readDeadline        time.Time
+	writeDeadline       time.Time
 
-	caPool *x509.CertPool
+	caPool              *x509.CertPool
 
 	onlyDHE             bool
 	onlyExports         bool
@@ -75,16 +75,16 @@ type Conn struct {
 	noSNI               bool
 	extendedRandom      bool
 
-	domain string
+	domain              string
 
 	// Encoding type
-	ReadEncoding string
+	ReadEncoding        string
 
 	// SSH
-	sshScan *SSHScanConfig
+	sshScan             *SSHScanConfig
 
 	// Errored component
-	erroredComponent string
+	erroredComponent    string
 }
 
 func (c *Conn) getUnderlyingConn() net.Conn {
@@ -232,6 +232,7 @@ func (c *Conn) makeHTTPRequest(config *HTTPConfig) (req *http.Request, encReq *H
 	} else {
 		userAgent = "Mozilla/5.0 zgrab/0.x"
 	}
+
 	req.Header.Set("User-Agent", userAgent)
 	encReq = new(HTTPRequest)
 	encReq.Endpoint = config.Endpoint
@@ -252,16 +253,16 @@ func (c *Conn) sendHTTPRequestReadHTTPResponse(req *http.Request, config *HTTPCo
 	var res *http.Response
 	if res, err = http.ReadResponse(reader, req); err != nil {
 		msg := err.Error()
-		if len(msg) > 1024*config.MaxSize {
-			err = errors.New(msg[0 : 1024*config.MaxSize])
+		if len(msg) > 1024 * config.MaxSize {
+			err = errors.New(msg[0 : 1024 * config.MaxSize])
 		}
 		return
 	}
 	var body []byte
 	if body, err = ioutil.ReadAll(res.Body); err != nil {
 		msg := err.Error()
-		if len(msg) > 1024*config.MaxSize {
-			err = errors.New(msg[0 : 1024*config.MaxSize])
+		if len(msg) > 1024 * config.MaxSize {
+			err = errors.New(msg[0 : 1024 * config.MaxSize])
 		}
 		return
 	}
@@ -272,8 +273,8 @@ func (c *Conn) sendHTTPRequestReadHTTPResponse(req *http.Request, config *HTTPCo
 	encRes.VersionMinor = res.ProtoMinor
 	encRes.Headers = HeadersFromGolangHeaders(res.Header)
 	var bodyOutput []byte
-	if len(body) > 1024*config.MaxSize {
-		bodyOutput = body[0 : 1024*config.MaxSize]
+	if len(body) > 1024 * config.MaxSize {
+		bodyOutput = body[0 : 1024 * config.MaxSize]
 	} else {
 		bodyOutput = body
 	}

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -336,6 +336,11 @@ func (c *Conn) doHTTP(config *HTTPConfig) error {
 	for redirectCount := 0; httpResponse.isRedirect() && httpResponse.canRedirectWithConn(c) && redirectCount < config.MaxRedirects; redirectCount++ {
 
 		var location string
+
+		if httpResponse.Headers["location"] == nil {
+			return fmt.Errorf("No location found for %d response from %s (%s)", httpResponse.StatusCode, c.domain, c.RemoteAddr())
+		}
+
 		if location = httpResponse.Headers["location"].(string); location == "" {
 			return fmt.Errorf("No location found for %d response from %s (%s)", httpResponse.StatusCode, c.domain, c.RemoteAddr())
 		}

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -48,20 +48,20 @@ const (
 // Implements the net.Conn interface
 type Conn struct {
 	// Underlying network connection
-	conn                net.Conn
-	tlsConn             *ztls.Conn
-	isTls               bool
+	conn    net.Conn
+	tlsConn *ztls.Conn
+	isTls   bool
 
-	grabData            GrabData
+	grabData GrabData
 
 	// Max TLS version
-	maxTlsVersion       uint16
+	maxTlsVersion uint16
 
 	// Cache the deadlines so we can reapply after TLS handshake
-	readDeadline        time.Time
-	writeDeadline       time.Time
+	readDeadline  time.Time
+	writeDeadline time.Time
 
-	caPool              *x509.CertPool
+	caPool *x509.CertPool
 
 	onlyDHE             bool
 	onlyExports         bool
@@ -75,16 +75,16 @@ type Conn struct {
 	noSNI               bool
 	extendedRandom      bool
 
-	domain              string
+	domain string
 
 	// Encoding type
-	ReadEncoding        string
+	ReadEncoding string
 
 	// SSH
-	sshScan             *SSHScanConfig
+	sshScan *SSHScanConfig
 
 	// Errored component
-	erroredComponent    string
+	erroredComponent string
 }
 
 func (c *Conn) getUnderlyingConn() net.Conn {
@@ -253,16 +253,16 @@ func (c *Conn) sendHTTPRequestReadHTTPResponse(req *http.Request, config *HTTPCo
 	var res *http.Response
 	if res, err = http.ReadResponse(reader, req); err != nil {
 		msg := err.Error()
-		if len(msg) > 1024 * config.MaxSize {
-			err = errors.New(msg[0 : 1024 * config.MaxSize])
+		if len(msg) > 1024*config.MaxSize {
+			err = errors.New(msg[0 : 1024*config.MaxSize])
 		}
 		return
 	}
 	var body []byte
 	if body, err = ioutil.ReadAll(res.Body); err != nil {
 		msg := err.Error()
-		if len(msg) > 1024 * config.MaxSize {
-			err = errors.New(msg[0 : 1024 * config.MaxSize])
+		if len(msg) > 1024*config.MaxSize {
+			err = errors.New(msg[0 : 1024*config.MaxSize])
 		}
 		return
 	}
@@ -273,8 +273,8 @@ func (c *Conn) sendHTTPRequestReadHTTPResponse(req *http.Request, config *HTTPCo
 	encRes.VersionMinor = res.ProtoMinor
 	encRes.Headers = HeadersFromGolangHeaders(res.Header)
 	var bodyOutput []byte
-	if len(body) > 1024 * config.MaxSize {
-		bodyOutput = body[0 : 1024 * config.MaxSize]
+	if len(body) > 1024*config.MaxSize {
+		bodyOutput = body[0 : 1024*config.MaxSize]
 	} else {
 		bodyOutput = body
 	}
@@ -325,7 +325,6 @@ func (c *Conn) doHTTP(config *HTTPConfig) error {
 
 	c.grabData.HTTP.Request = httpRequest
 	c.grabData.HTTP.Response = httpResponse
-
 
 	for redirectCount := 0; httpResponse.isRedirect() && httpResponse.canRedirectWithConn(c) && redirectCount < config.MaxRedirects; redirectCount++ {
 

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -268,6 +268,8 @@ func (c *Conn) sendHTTPRequestReadHTTPResponse(req *http.Request, config *HTTPCo
 	encRes = new(HTTPResponse)
 	encRes.StatusCode = res.StatusCode
 	encRes.StatusLine = res.Proto + " " + res.Status
+	encRes.VersionMajor = res.ProtoMajor
+	encRes.VersionMinor = res.ProtoMinor
 	encRes.Headers = HeadersFromGolangHeaders(res.Header)
 	var bodyOutput []byte
 	if len(body) > 1024*config.MaxSize {

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -330,7 +330,6 @@ func (c *Conn) doHTTP(config *HTTPConfig) error {
 	for redirectCount := 0; httpResponse.isRedirect() && httpResponse.canRedirectWithConn(c) && redirectCount < config.MaxRedirects; redirectCount++ {
 
 		var location string
-		// TODO: Should we error here or just store an empty redirect response?
 		if location = httpResponse.Headers["location"].(string); location == "" {
 			return fmt.Errorf("No location found for %d response from %s (%s)", httpResponse.StatusCode, c.domain, c.RemoteAddr())
 		}
@@ -360,9 +359,6 @@ func (c *Conn) doHTTP(config *HTTPConfig) error {
 		default:
 			return fmt.Errorf("Invalid redirect response code: %d from %s (%s)", httpResponse.StatusCode, c.domain, c.RemoteAddr())
 		}
-
-		// TODO: handle the case where we redirect to a different proto/host
-
 	}
 
 	return nil

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -254,6 +254,7 @@ func (c *Conn) sendHTTPRequestReadHTTPResponse(req *http.Request, config *HTTPCo
 		req.Method = "HEAD" // fuck you golang
 	}
 	reader := bufio.NewReader(uc)
+
 	var res *http.Response
 	if res, err = http.ReadResponse(reader, req); err != nil {
 		msg := err.Error()
@@ -262,6 +263,8 @@ func (c *Conn) sendHTTPRequestReadHTTPResponse(req *http.Request, config *HTTPCo
 		}
 		return
 	}
+	defer res.Body.Close()
+
 	var body []byte
 	if body, err = ioutil.ReadAll(res.Body); err != nil {
 		msg := err.Error()

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -338,6 +338,7 @@ func (c *Conn) doHTTP(config *HTTPConfig) error {
 			if locationUrl, err := url.Parse(location); err != nil {
 				return err
 			} else {
+				c.domain = locationUrl.Host
 				config.Endpoint = locationUrl.RequestURI()
 			}
 

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -255,6 +255,8 @@ func makeGrabber(config *Config) func(*Conn) error {
 			config.ErrorLog.Errorf("Conversation error with remote host %s: %s",
 				c.RemoteAddr().String(), err.Error())
 		}
+
+		c.Close()
 		return err
 	}
 }

--- a/zlib/http.go
+++ b/zlib/http.go
@@ -16,8 +16,8 @@ package zlib
 
 import (
 	"net/http"
-	"strings"
 	"net/url"
+	"strings"
 )
 
 var knownHeaders map[string]int
@@ -66,8 +66,8 @@ type HTTPRequest struct {
 }
 
 type HTTPResponse struct {
-	VersionMajor int      `json:"version_major",omitempty"`
-	VersionMinor int      `json:"version_minor",omitempty"`
+	VersionMajor int         `json:"version_major",omitempty"`
+	VersionMinor int         `json:"version_minor",omitempty"`
 	StatusCode   int         `json:"status_code,omitempty"`
 	StatusLine   string      `json:"status_line,omitempty"`
 	Headers      HTTPHeaders `json:"headers,omitempty"`
@@ -76,11 +76,11 @@ type HTTPResponse struct {
 }
 
 type HTTPRequestResponse struct {
-	ProxyRequest      *HTTPRequest  `json:"connect_request,omitempty"`
-	ProxyResponse     *HTTPResponse `json:"connect_response,omitempty"`
-	Request           *HTTPRequest  `json:"request,omitempty"`
-	Response          *HTTPResponse `json:"response,omitempty"`
-	RedirectRequests  []*HTTPRequest `json:"redirect_requests,omitempty"`
+	ProxyRequest      *HTTPRequest    `json:"connect_request,omitempty"`
+	ProxyResponse     *HTTPResponse   `json:"connect_response,omitempty"`
+	Request           *HTTPRequest    `json:"request,omitempty"`
+	Response          *HTTPResponse   `json:"response,omitempty"`
+	RedirectRequests  []*HTTPRequest  `json:"redirect_requests,omitempty"`
 	RedirectResponses []*HTTPResponse `json:"redirect_responses,omitempty"`
 }
 
@@ -153,14 +153,18 @@ func (response HTTPResponse) isRedirect() bool {
 func (response HTTPResponse) canRedirectWithConn(conn *Conn) bool {
 
 	targetUrl, targetUrlError := url.Parse(conn.domain)
-	if (targetUrlError != nil) { return false }
+	if targetUrlError != nil {
+		return false
+	}
 
 	redirectUrl, redirectUrlError := url.Parse(response.Headers["location"].(string))
-	if (redirectUrlError != nil) { return false }
+	if redirectUrlError != nil {
+		return false
+	}
 
 	// Either explicit keep-alive or HTTP 1.1, which uses persistent connections by default
 	var keepAlive bool
-	if (response.Headers["Connection"] != nil) {
+	if response.Headers["Connection"] != nil {
 		keepAlive = strings.EqualFold(response.Headers["Connection"].(string), "keep-alive")
 	} else {
 		keepAlive = response.VersionMajor == 1 && response.VersionMinor == 1
@@ -171,4 +175,3 @@ func (response HTTPResponse) canRedirectWithConn(conn *Conn) bool {
 
 	return matchesHost && matchesProto && keepAlive
 }
-

--- a/zlib/http.go
+++ b/zlib/http.go
@@ -68,20 +68,20 @@ type HTTPRequest struct {
 type HTTPResponse struct {
 	VersionMajor int      `json:"version_major",omitempty"`
 	VersionMinor int      `json:"version_minor",omitempty"`
-	StatusCode int         `json:"status_code,omitempty"`
-	StatusLine string      `json:"status_line,omitempty"`
-	Headers    HTTPHeaders `json:"headers,omitempty"`
-	Body       string      `json:"body,omitempty"`
-	BodySHA256 []byte      `json:"body_sha256,omitempty"`
+	StatusCode   int         `json:"status_code,omitempty"`
+	StatusLine   string      `json:"status_line,omitempty"`
+	Headers      HTTPHeaders `json:"headers,omitempty"`
+	Body         string      `json:"body,omitempty"`
+	BodySHA256   []byte      `json:"body_sha256,omitempty"`
 }
 
 type HTTPRequestResponse struct {
-	ProxyRequest  		*HTTPRequest  `json:"connect_request,omitempty"`
-	ProxyResponse 		*HTTPResponse `json:"connect_response,omitempty"`
-	Request       		*HTTPRequest  `json:"request,omitempty"`
-	Response      		*HTTPResponse `json:"response,omitempty"`
-	RedirectRequests 	[]*HTTPRequest `json:"redirect_requests,omitempty"`
-	RedirectResponses 	[]*HTTPResponse `json:"redirect_responses,omitempty"`
+	ProxyRequest      *HTTPRequest  `json:"connect_request,omitempty"`
+	ProxyResponse     *HTTPResponse `json:"connect_response,omitempty"`
+	Request           *HTTPRequest  `json:"request,omitempty"`
+	Response          *HTTPResponse `json:"response,omitempty"`
+	RedirectRequests  []*HTTPRequest `json:"redirect_requests,omitempty"`
+	RedirectResponses []*HTTPResponse `json:"redirect_responses,omitempty"`
 }
 
 func init() {

--- a/zlib/http.go
+++ b/zlib/http.go
@@ -158,6 +158,10 @@ func (response HTTPResponse) canRedirectWithConn(conn *Conn) bool {
 		return false
 	}
 
+	if response.Headers["location"] == nil {
+		return false
+	}
+
 	redirectUrl, redirectUrlError := url.Parse(response.Headers["location"].(string))
 	if redirectUrlError != nil {
 		return false

--- a/zlib/http.go
+++ b/zlib/http.go
@@ -15,6 +15,7 @@
 package zlib
 
 import (
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -162,6 +163,11 @@ func (response HTTPResponse) canRedirectWithConn(conn *Conn) bool {
 		return false
 	}
 
+	remoteIpAddress, _, remoteIpAddressErr := net.SplitHostPort(conn.RemoteAddr().String())
+	if remoteIpAddressErr != nil {
+		return false
+	}
+
 	// Either explicit keep-alive or HTTP 1.1, which uses persistent connections by default
 	var keepAlive bool
 	if response.Headers["Connection"] != nil {
@@ -170,7 +176,7 @@ func (response HTTPResponse) canRedirectWithConn(conn *Conn) bool {
 		keepAlive = response.VersionMajor == 1 && response.VersionMinor == 1
 	}
 
-	matchesHost := targetUrl.Host == redirectUrl.Host
+	matchesHost := (targetUrl.Host == redirectUrl.Host) || (redirectUrl.Host == remoteIpAddress)
 	matchesProto := (conn.isTls && redirectUrl.Scheme == "https") || (!conn.isTls && redirectUrl.Scheme == "http")
 
 	return matchesHost && matchesProto && keepAlive

--- a/zlib/http.go
+++ b/zlib/http.go
@@ -169,7 +169,7 @@ func (response HTTPResponse) canRedirectWithConn(conn *Conn) bool {
 	}
 
 	relativePath := redirectUrl.Host == ""
-	matchesHost := (targetUrl.Host == redirectUrl.Host) || (redirectUrl.Host == remoteIpAddress)
+	matchesHost := (strings.Contains(redirectUrl.Host, targetUrl.Host)) || (redirectUrl.Host == remoteIpAddress)
 	matchesProto := (conn.isTls && redirectUrl.Scheme == "https") || (!conn.isTls && redirectUrl.Scheme == "http")
 
 	// Either explicit keep-alive or HTTP 1.1, which uses persistent connections by default

--- a/zlib/http.go
+++ b/zlib/http.go
@@ -65,6 +65,8 @@ type HTTPRequest struct {
 }
 
 type HTTPResponse struct {
+	VersionMajor int      `json:"version_major",omitempty"`
+	VersionMinor int      `json:"version_minor",omitempty"`
 	StatusCode int         `json:"status_code,omitempty"`
 	StatusLine string      `json:"status_line,omitempty"`
 	Headers    HTTPHeaders `json:"headers,omitempty"`


### PR DESCRIPTION
@dadrian @zakird 

Basic HTTP / HTTPS redirects under the following conditions:
1) the --http-max-redirects option is set > 0
2) domain is specified alongside/after IP address (separated by a comma)
3) the redirect location matches the domain, and has the same HTTP or HTTPS protocol as the original connection
4) the initial HTTP response has the "Keep-Alive" header or HTTP 1.1, which uses persistent connections by default

What is the best way to test this? I have only verified that it works with a local test Rails server. I'm hesitant to try the Alexa Top Million from my laptop...
