### PR TITLE
use terminal response as top level response

### DIFF
--- a/zgrab_schema.py
+++ b/zgrab_schema.py
@@ -330,6 +330,8 @@ zgrab_http_request = SubRecord({
 })
 
 zgrab_http_response = SubRecord({
+    "version_major":Integer(),
+    "version_minor":Integer(),
     "status_code":Integer(),
     "status_line":AnalyzedString(),
     "body":HTML(),

--- a/zgrab_schema.py
+++ b/zgrab_schema.py
@@ -337,11 +337,16 @@ zgrab_http_response = SubRecord({
     "headers":zgrab_http_headers
 })
 
+zgrab_http_request_response = SubRecord({
+    "request":zgrab_http_request,
+    "response":zgrab_http_response
+})
+
 zgrab_http = Record({
     "data":SubRecord({
       "http":SubRecord({
-        "request":zgrab_http_request,
-        "response":zgrab_http_response
+        "response":zgrab_http_response,
+        "request_response_chain":ListOf(zgrab_http_request_response)
       })
     })
 }, extends=zgrab_base)

--- a/zlib/http.go
+++ b/zlib/http.go
@@ -76,13 +76,16 @@ type HTTPResponse struct {
 	BodySHA256   []byte      `json:"body_sha256,omitempty"`
 }
 
+type HTTP struct {
+	ProxyRequest         *HTTPRequest           `json:"connect_request,omitempty"`
+	ProxyResponse        *HTTPResponse          `json:"connect_response,omitempty"`
+	Response             *HTTPResponse          `json:"response,omitempty"`
+	RequestResponseChain []*HTTPRequestResponse `json:"request_response_chain,omitempty"`
+}
+
 type HTTPRequestResponse struct {
-	ProxyRequest      *HTTPRequest    `json:"connect_request,omitempty"`
-	ProxyResponse     *HTTPResponse   `json:"connect_response,omitempty"`
-	Request           *HTTPRequest    `json:"request,omitempty"`
-	Response          *HTTPResponse   `json:"response,omitempty"`
-	RedirectRequests  []*HTTPRequest  `json:"redirect_requests,omitempty"`
-	RedirectResponses []*HTTPResponse `json:"redirect_responses,omitempty"`
+	Request  *HTTPRequest  `json:"request,omitempty"`
+	Response *HTTPResponse `json:"response,omitempty"`
 }
 
 func init() {

--- a/zlib/zgrab.go
+++ b/zlib/zgrab.go
@@ -50,7 +50,7 @@ type GrabData struct {
 	SMTPHelp     *SMTPHelpEvent        `json:"smtp_help,omitempty"`
 	StartTLS     string                `json:"starttls,omitempty"`
 	TLSHandshake *ztls.ServerHandshake `json:"tls,omitempty"`
-	HTTP         *HTTPRequestResponse  `json:"http,omitempty"`
+	HTTP         *HTTP                 `json:"http,omitempty"`
 	Heartbleed   *ztls.Heartbleed      `json:"heartbleed,omitempty"`
 	Modbus       *ModbusEvent          `json:"modbus,omitempty"`
 	SSH          *ssh.HandshakeLog     `json:"ssh,omitempty"`


### PR DESCRIPTION
@zakird @dadrian 

Minor tweak to HTTP redirects. Previously we were storing the initial HTTP response (aka a 300 response) as the top-level HTTPRequestResponse.response, and the terminal 200 response was being stored as the last element of HTTPRequestResponse.redirect_responses. I've change it so that HTTPRequestResponse.response now contains the terminal response at the end of max-redirects, and moved the initial http response to be the first item of HTTPRequestResponse.redirect_responses.

One concern I have is that the requests and responses are misaligned. HTTPRequestResponse.request does not directly return HTTPRequestResponse.response. Also the HTTPRequestResponse.redirect_requests and HTTPRequestResponse.redirect_responses are off-by-one. Are we okay with this?