### PR TITLE
Fix nil interface conversion error

### DIFF
--- a/zlib/http.go
+++ b/zlib/http.go
@@ -158,7 +158,12 @@ func (response HTTPResponse) canRedirectWithConn(conn *Conn) bool {
 		return false
 	}
 
-	redirectUrl, redirectUrlError := url.Parse(response.Headers["location"].(string))
+	locationHeaders, ok := response.Headers["location"]
+	if !ok || locationHeaders == nil {
+		return false
+	}
+
+	redirectUrl, redirectUrlError := url.Parse(locationHeaders.(string))
 	if redirectUrlError != nil {
 		return false
 	}


### PR DESCRIPTION
This should fix the following error. @zzma, can you double check?

```
panic: interface conversion: interface is nil, not string

goroutine 505 [running]:
github.com/zmap/zgrab/zlib.HTTPResponse.canRedirectWithConn(0x1, 0x1, 0x12d, 0xc20aff1cc0, 0x1e, 0xc2093fd1a0, 0xc20bae4000, 0x27a4, 0xc20aff1ee0, 0x20, ...)
	/var/search/tmp/gopath_vab9w56a/src/github.com/zmap/zgrab/zlib/http.go:161 +0x104
github.com/zmap/zgrab/zlib.(*Conn).doHTTP(0xc20da33a40, 0xb36408, 0x0, 0x0)
	/var/search/tmp/gopath_vab9w56a/src/github.com/zmap/zgrab/zlib/conn.go:333 +0x207
github.com/zmap/zgrab/zlib.(*Conn).HTTP(0xc20da33a40, 0xb36408, 0x0, 0x0)
	/var/search/tmp/gopath_vab9w56a/src/github.com/zmap/zgrab/zlib/conn.go:206 +0x8f
github.com/zmap/zgrab/zlib.func·002(0xc20da33a40, 0x0, 0x0)
	/var/search/tmp/gopath_vab9w56a/src/github.com/zmap/zgrab/zlib/grabber.go:177 +0x653
github.com/zmap/zgrab/zlib.func·003(0xc20da33a40, 0x0, 0x0)
	/var/search/tmp/gopath_vab9w56a/src/github.com/zmap/zgrab/zlib/grabber.go:253 +0x5b
github.com/zmap/zgrab/zlib.GrabBanner(0xb36340, 0xc20d9f17d0, 0xc20b60e7b0)
	/var/search/tmp/gopath_vab9w56a/src/github.com/zmap/zgrab/zlib/grabber.go:287 +0x58e
github.com/zmap/zgrab/zlib.func·004(0x77e7a0, 0xc20b60e7b0, 0x0, 0x0)
	/var/search/tmp/gopath_vab9w56a/src/github.com/zmap/zgrab/zlib/processing.go:66 +0xf5
github.com/zmap/zgrab/ztools/processing.func·002(0xc20816fa40)
	/var/search/tmp/gopath_vab9w56a/src/github.com/zmap/zgrab/ztools/processing/input.go:70 +0xfb
created by github.com/zmap/zgrab/ztools/processing.Process
	/var/search/tmp/gopath_vab9w56a/src/github.com/zmap/zgrab/ztools/processing/input.go:79 +0x3a5
```

