### PR TITLE
strict host matching for redirect urls

### DIFF
--- a/zlib/http.go
+++ b/zlib/http.go
@@ -15,6 +15,7 @@
 package zlib
 
 import (
+	"github.com/zmap/zgrab/ztools/util"
 	"net"
 	"net/http"
 	"net/url"
@@ -176,8 +177,15 @@ func (response HTTPResponse) canRedirectWithConn(conn *Conn) bool {
 		return false
 	}
 
-	relativePath := redirectUrl.Host == ""
-	matchesHost := (strings.Contains(redirectUrl.Host, targetUrl.Host)) || (redirectUrl.Host == remoteIpAddress)
+	targetHost := targetUrl.Host
+	if targetHost == "" {
+		targetHost = conn.domain
+	}
+	redirectHost := redirectUrl.Host
+
+	relativePath := redirectHost == ""
+	matchesHost := (strings.Contains(redirectHost, targetHost) && util.TLDMatches(redirectHost, targetHost)) ||
+		(redirectHost == remoteIpAddress)
 	matchesProto := (conn.isTls && redirectUrl.Scheme == "https") || (!conn.isTls && redirectUrl.Scheme == "http")
 
 	// Either explicit keep-alive or HTTP 1.1, which uses persistent connections by default

--- a/zlib/processing.go
+++ b/zlib/processing.go
@@ -16,7 +16,6 @@ package zlib
 
 import (
 	"encoding/json"
-
 	"github.com/zmap/zgrab/ztools/processing"
 )
 

--- a/ztools/util/util.go
+++ b/ztools/util/util.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"net"
 	"regexp"
+	"strings"
 )
 
 func ReadUntilRegex(connection net.Conn, res []byte, expr *regexp.Regexp) (int, error) {
@@ -33,4 +34,19 @@ func ReadUntilRegex(connection net.Conn, res []byte, expr *regexp.Regexp) (int, 
 		buf = res[length:]
 	}
 	return length, nil
+}
+
+// Checks for a strict TLD match
+func TLDMatches(host1 string, host2 string) bool {
+	splitStr1 := strings.Split(StripPortNumber(host1), ".")
+	splitStr2 := strings.Split(StripPortNumber(host2), ".")
+
+	tld1 := splitStr1[len(splitStr1)-1]
+	tld2 := splitStr2[len(splitStr2)-1]
+
+	return tld1 == tld2
+}
+
+func StripPortNumber(host string) string {
+	return strings.Split(host, ":")[0]
 }


### PR DESCRIPTION
addressing issue: https://github.com/zmap/zgrab/issues/88

@dadrian

Make sure we also check that the TLD matches, when doing redirect-ability checking. 