### PR TITLE
don't zlog.Error to stderr

### DIFF
--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -35,7 +35,6 @@ import (
 	"github.com/zmap/zgrab/ztools/ssh"
 	"github.com/zmap/zgrab/ztools/util"
 	"github.com/zmap/zgrab/ztools/x509"
-	"github.com/zmap/zgrab/ztools/zlog"
 	"github.com/zmap/zgrab/ztools/ztls"
 )
 
@@ -361,7 +360,7 @@ func (c *Conn) doHTTP(config *HTTPConfig) error {
 
 			if httpResponse, err = c.sendHTTPRequestReadHTTPResponse(redirectBaseRequest, config); err != nil {
 				if err == io.ErrUnexpectedEOF {
-					zlog.Errorf("Connection closed before making redirect to %s (%s)", c.domain, c.RemoteAddr())
+					return errors.New(fmt.Sprint("Connection closed before making redirect to %s (%s)", c.domain, c.RemoteAddr()))
 				}
 				return err
 			}


### PR DESCRIPTION
stop writing to stderr. I didn't want to have to pass the config ErrorLog all the way down, so I created a new error that gets sent up the pipeline and logged properly. 