### PR TITLE
Add ability to gather TLS Session Tickets.

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,6 +108,9 @@ func init() {
 	flag.BoolVar(&config.SafariNoDHE, "safari-no-dhe-ciphers", false, "Send Safari ciphers minus DHE suites")
 
 	flag.BoolVar(&config.Heartbleed, "heartbleed", false, "Check if server is vulnerable to Heartbleed (implies --tls)")
+
+	flag.BoolVar(&config.GatherSessionTicket, "tls-session-ticket-ext", false, "Send support for TLS Session Tickets and output ticket if presented")
+
 	flag.StringVar(&rootCAFileName, "ca-file", "", "List of trusted root certificate authorities in PEM format")
 	flag.IntVar(&config.GOMAXPROCS, "gomaxprocs", 3, "Set GOMAXPROCS (default 3)")
 	flag.BoolVar(&config.FTP, "ftp", false, "Read FTP banners")

--- a/zlib/config.go
+++ b/zlib/config.go
@@ -98,21 +98,22 @@ type Config struct {
 	Encoding string
 
 	// TLS
-	TLS               bool
-	TLSVersion        uint16
-	Heartbleed        bool
-	RootCAPool        *x509.CertPool
-	DHEOnly           bool
-	ExportsOnly       bool
-	ExportsDHOnly     bool
-	FirefoxOnly       bool
-	FirefoxNoDHE      bool
-	ChromeOnly        bool
-	ChromeNoDHE       bool
-	SafariOnly        bool
-	SafariNoDHE       bool
-	NoSNI             bool
-	TLSExtendedRandom bool
+	TLS                 bool
+	TLSVersion          uint16
+	Heartbleed          bool
+	RootCAPool          *x509.CertPool
+	DHEOnly             bool
+	ExportsOnly         bool
+	ExportsDHOnly       bool
+	FirefoxOnly         bool
+	FirefoxNoDHE        bool
+	ChromeOnly          bool
+	ChromeNoDHE         bool
+	SafariOnly          bool
+	SafariNoDHE         bool
+	NoSNI               bool
+	TLSExtendedRandom   bool
+	GatherSessionTicket bool
 
 	// SSH
 	SSH SSHScanConfig

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -77,6 +77,7 @@ type Conn struct {
 	safariNoDHECiphers  bool
 	noSNI               bool
 	extendedRandom      bool
+	gatherSessionTicket bool
 
 	domain string
 
@@ -147,6 +148,10 @@ func (c *Conn) SetDomain(domain string) {
 
 func (c *Conn) SetNoSNI() {
 	c.noSNI = true
+}
+
+func (c *Conn) SetGatherSessionTicket() {
+	c.gatherSessionTicket = true
 }
 
 // Layer in the regular conn methods
@@ -459,6 +464,11 @@ func (c *Conn) TLSHandshake() error {
 	}
 	if c.extendedRandom {
 		tlsConfig.ExtendedRandom = true
+	}
+	if c.gatherSessionTicket {
+		tlsConfig.SessionTicketsDisabled = false
+	} else {
+		tlsConfig.SessionTicketsDisabled = true
 	}
 
 	c.tlsConn = ztls.Client(c.conn, tlsConfig)

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -19,16 +19,16 @@ import (
 	"encoding/csv"
 	"errors"
 	"fmt"
-	"io"
-	"net"
-	"strconv"
-	"time"
 	"github.com/zmap/zgrab/ztools/ftp"
 	"github.com/zmap/zgrab/ztools/processing"
 	"github.com/zmap/zgrab/ztools/scada/dnp3"
 	"github.com/zmap/zgrab/ztools/scada/fox"
 	"github.com/zmap/zgrab/ztools/scada/siemens"
 	"github.com/zmap/zgrab/ztools/telnet"
+	"io"
+	"net"
+	"strconv"
+	"time"
 )
 
 type GrabTarget struct {
@@ -126,6 +126,9 @@ func makeGrabber(config *Config) func(*Conn) error {
 		}
 		if config.TLSExtendedRandom {
 			c.SetExtendedRandom()
+		}
+		if config.GatherSessionTicket {
+			c.SetGatherSessionTicket()
 		}
 
 		if config.SSH.SSH {

--- a/ztools/ztls/handshake_client.go
+++ b/ztools/ztls/handshake_client.go
@@ -55,6 +55,12 @@ func (c *Conn) clientHandshake() error {
 		secureRenegotiation: true,
 	}
 
+	if c.config.SessionTicketsDisabled {
+		hello.ticketSupported = false
+	} else {
+		hello.ticketSupported = true
+	}
+
 	if c.config.HeartbeatEnabled && !c.config.ExtendedRandom {
 		hello.heartbeatEnabled = true
 		hello.heartbeatMode = heartbeatModePeerAllowed
@@ -236,6 +242,12 @@ func (c *Conn) clientHandshake() error {
 		if err := hs.readFinished(); err != nil {
 			return err
 		}
+	}
+
+	if hs.session == nil {
+		c.handshakeLog.SessionTicket = nil
+	} else {
+		c.handshakeLog.SessionTicket = hs.session.MakeLog()
 	}
 
 	if sessionCache != nil && hs.session != nil && session != hs.session {

--- a/ztools/ztls/ztls_handshake.go
+++ b/ztools/ztls/ztls_handshake.go
@@ -70,6 +70,12 @@ type Finished struct {
 	VerifyData []byte `json:"verify_data"`
 }
 
+// SessionTicket represents the new session ticket sent by the server to the
+// client
+type SessionTicket struct {
+	Value []uint8 `json:"value,omitempty"`
+}
+
 // ServerHandshake stores all of the messages sent by the server during a standard TLS Handshake.
 // It implements zgrab.EventData interface
 type ServerHandshake struct {
@@ -78,6 +84,7 @@ type ServerHandshake struct {
 	ServerCertificates *Certificates      `json:"server_certificates,omitempty"`
 	ServerKeyExchange  *ServerKeyExchange `json:"server_key_exchange,omitempty"`
 	ServerFinished     *Finished          `json:"server_finished,omitempty"`
+	SessionTicket      *SessionTicket     `json:"session_ticket,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshler interface
@@ -259,4 +266,11 @@ func (m *finishedMsg) MakeLog() *Finished {
 	sf.VerifyData = make([]byte, len(m.verifyData))
 	copy(sf.VerifyData, m.verifyData)
 	return sf
+}
+
+func (m *ClientSessionState) MakeLog() *SessionTicket {
+	st := new(SessionTicket)
+	st.Value = make([]uint8, len(m.sessionTicket))
+	copy(st.Value, m.sessionTicket)
+	return st
 }


### PR DESCRIPTION
The --tls-session-ticket-ext flag adds the Session Ticket extension
support to TLS Client Hello. If the server sends a New Session Ticket
payload, then the ticket value is extracted and saved in JSON output.