### PR TITLE
Add RFC 7627 Extended Master Secret extension

### DIFF
--- a/main.go
+++ b/main.go
@@ -111,6 +111,8 @@ func init() {
 
 	flag.BoolVar(&config.GatherSessionTicket, "tls-session-ticket", false, "Send support for TLS Session Tickets and output ticket if presented")
 
+	flag.BoolVar(&config.ExtendedMasterSecret, "tls-extended-master-secret", false, "Offer RFC 7627 Extended Master Secret extension")
+
 	flag.StringVar(&rootCAFileName, "ca-file", "", "List of trusted root certificate authorities in PEM format")
 	flag.IntVar(&config.GOMAXPROCS, "gomaxprocs", 3, "Set GOMAXPROCS (default 3)")
 	flag.BoolVar(&config.FTP, "ftp", false, "Read FTP banners")

--- a/zgrab_schema.py
+++ b/zgrab_schema.py
@@ -136,6 +136,7 @@ zgrab_tls = SubRecord({
         "secure_renegotiation":Boolean(),
         "heartbeat":Boolean(),
         "extended_random":Binary(),
+        "extended_master_secret":Boolean(),
     }),
     "server_certificates":SubRecord({
         "certificate":zgrab_certificate,

--- a/zlib/config.go
+++ b/zlib/config.go
@@ -98,22 +98,23 @@ type Config struct {
 	Encoding string
 
 	// TLS
-	TLS                 bool
-	TLSVersion          uint16
-	Heartbleed          bool
-	RootCAPool          *x509.CertPool
-	DHEOnly             bool
-	ExportsOnly         bool
-	ExportsDHOnly       bool
-	FirefoxOnly         bool
-	FirefoxNoDHE        bool
-	ChromeOnly          bool
-	ChromeNoDHE         bool
-	SafariOnly          bool
-	SafariNoDHE         bool
-	NoSNI               bool
-	TLSExtendedRandom   bool
-	GatherSessionTicket bool
+	TLS                  bool
+	TLSVersion           uint16
+	Heartbleed           bool
+	RootCAPool           *x509.CertPool
+	DHEOnly              bool
+	ExportsOnly          bool
+	ExportsDHOnly        bool
+	FirefoxOnly          bool
+	FirefoxNoDHE         bool
+	ChromeOnly           bool
+	ChromeNoDHE          bool
+	SafariOnly           bool
+	SafariNoDHE          bool
+	NoSNI                bool
+	TLSExtendedRandom    bool
+	GatherSessionTicket  bool
+	ExtendedMasterSecret bool
 
 	// SSH
 	SSH SSHScanConfig

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -66,18 +66,19 @@ type Conn struct {
 
 	caPool *x509.CertPool
 
-	onlyDHE             bool
-	onlyExports         bool
-	onlyExportsDH       bool
-	chromeCiphers       bool
-	chromeNoDHE         bool
-	firefoxCiphers      bool
-	firefoxNoDHECiphers bool
-	safariCiphers       bool
-	safariNoDHECiphers  bool
-	noSNI               bool
-	extendedRandom      bool
-	gatherSessionTicket bool
+	onlyDHE                   bool
+	onlyExports               bool
+	onlyExportsDH             bool
+	chromeCiphers             bool
+	chromeNoDHE               bool
+	firefoxCiphers            bool
+	firefoxNoDHECiphers       bool
+	safariCiphers             bool
+	safariNoDHECiphers        bool
+	noSNI                     bool
+	extendedRandom            bool
+	gatherSessionTicket       bool
+	offerExtendedMasterSecret bool
 
 	domain string
 
@@ -152,6 +153,10 @@ func (c *Conn) SetNoSNI() {
 
 func (c *Conn) SetGatherSessionTicket() {
 	c.gatherSessionTicket = true
+}
+
+func (c *Conn) SetExtendedMasterSecret() {
+	c.offerExtendedMasterSecret = true
 }
 
 // Layer in the regular conn methods
@@ -467,6 +472,9 @@ func (c *Conn) TLSHandshake() error {
 	}
 	if c.gatherSessionTicket {
 		tlsConfig.ForceSessionTicketExt = true
+	}
+	if c.offerExtendedMasterSecret {
+		tlsConfig.ExtendedMasterSecret = true
 	}
 
 	c.tlsConn = ztls.Client(c.conn, tlsConfig)

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -130,6 +130,9 @@ func makeGrabber(config *Config) func(*Conn) error {
 		if config.GatherSessionTicket {
 			c.SetGatherSessionTicket()
 		}
+		if config.ExtendedMasterSecret {
+			c.SetExtendedMasterSecret()
+		}
 
 		if config.SSH.SSH {
 			c.sshScan = &config.SSH

--- a/ztools/ztls/common.go
+++ b/ztools/ztls/common.go
@@ -73,15 +73,16 @@ const (
 
 // TLS extension numbers
 const (
-	extensionServerName          uint16 = 0
-	extensionStatusRequest       uint16 = 5
-	extensionSupportedCurves     uint16 = 10
-	extensionSupportedPoints     uint16 = 11
-	extensionSignatureAlgorithms uint16 = 13
-	extensionSessionTicket       uint16 = 35
-	extensionNextProtoNeg        uint16 = 13172 // not IANA assigned
-	extensionRenegotiationInfo   uint16 = 0xff01
-	extensionExtendedRandom      uint16 = 0x0028 // not IANA assigned
+	extensionServerName           uint16 = 0
+	extensionStatusRequest        uint16 = 5
+	extensionSupportedCurves      uint16 = 10
+	extensionSupportedPoints      uint16 = 11
+	extensionSignatureAlgorithms  uint16 = 13
+	extensionSessionTicket        uint16 = 35
+	extensionNextProtoNeg         uint16 = 13172 // not IANA assigned
+	extensionRenegotiationInfo    uint16 = 0xff01
+	extensionExtendedRandom       uint16 = 0x0028 // not IANA assigned
+	extensionExtendedMasterSecret uint16 = 0x0017
 )
 
 // TLS signaling cipher suite values
@@ -340,6 +341,9 @@ type Config struct {
 
 	// Force Client Hello to send TLS Session Ticket extension
 	ForceSessionTicketExt bool
+
+	// Send RFC 7627 Extended Master Secret extension in Client Hello
+	ExtendedMasterSecret bool
 }
 
 func (c *Config) serverInit() {

--- a/ztools/ztls/handshake_client.go
+++ b/ztools/ztls/handshake_client.go
@@ -59,6 +59,10 @@ func (c *Conn) clientHandshake() error {
 		hello.ticketSupported = true
 	}
 
+	if c.config.ExtendedMasterSecret {
+		hello.extendedMasterSecretEnabled = true
+	}
+
 	if c.config.HeartbeatEnabled && !c.config.ExtendedRandom {
 		hello.heartbeatEnabled = true
 		hello.heartbeatMode = heartbeatModePeerAllowed

--- a/ztools/ztls/handshake_client.go
+++ b/ztools/ztls/handshake_client.go
@@ -512,7 +512,7 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 		c.writeRecord(recordTypeHandshake, ckx.marshal())
 	}
 
-	if c.config.ExtendedMasterSecret {
+	if hs.hello.extendedMasterSecretEnabled && hs.serverHello.extendedMasterSecretEnabled {
 		session_hash = hs.finishedHash.Sum()
 	}
 
@@ -589,7 +589,7 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 		sr = hs.serverHello.random
 	}
 
-	if c.config.ExtendedMasterSecret {
+	if hs.hello.extendedMasterSecretEnabled && hs.serverHello.extendedMasterSecretEnabled {
 		hs.masterSecret = extendedMasterFromPreMasterSecret(c.vers, hs.suite, preMasterSecret, session_hash)
 	} else {
 		hs.masterSecret = masterFromPreMasterSecret(c.vers, hs.suite, preMasterSecret, cr, sr)

--- a/ztools/ztls/handshake_server.go
+++ b/ztools/ztls/handshake_server.go
@@ -395,7 +395,7 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 	}
 	hs.finishedHash.Write(ckx.marshal())
 
-	if c.config.ExtendedMasterSecret {
+	if hs.hello.extendedMasterSecretEnabled && hs.clientHello.extendedMasterSecretEnabled {
 		session_hash = hs.finishedHash.Sum()
 	}
 
@@ -484,7 +484,8 @@ func (hs *serverHandshakeState) doFullHandshake() error {
 		c.sendAlert(alertHandshakeFailure)
 		return err
 	}
-	if c.config.ExtendedMasterSecret {
+
+	if hs.hello.extendedMasterSecretEnabled && hs.clientHello.extendedMasterSecretEnabled {
 		hs.masterSecret = extendedMasterFromPreMasterSecret(c.vers, hs.suite, preMasterSecret, session_hash)
 	} else {
 		hs.masterSecret = masterFromPreMasterSecret(c.vers, hs.suite, preMasterSecret, hs.clientHello.random, hs.hello.random)

--- a/ztools/ztls/prf.go
+++ b/ztools/ztls/prf.go
@@ -162,10 +162,8 @@ func masterFromPreMasterSecret(version uint16, suite *cipherSuite, preMasterSecr
 // extendedMasterFromPreMasterSecret generates the master secret from the
 // premaster secret. See https://tools.ietf.org/html/rfc7627#section-4
 func extendedMasterFromPreMasterSecret(version uint16, suite *cipherSuite, preMasterSecret, session_hash []byte) []byte {
-	seed := make([]byte, len(session_hash))
-	copy(seed, session_hash)
 	masterSecret := make([]byte, masterSecretLength)
-	prfForVersion(version, suite)(masterSecret, preMasterSecret, extendedMasterSecretLabel, seed[0:])
+	prfForVersion(version, suite)(masterSecret, preMasterSecret, extendedMasterSecretLabel, session_hash[0:])
 	return masterSecret
 }
 

--- a/ztools/ztls/prf.go
+++ b/ztools/ztls/prf.go
@@ -124,6 +124,7 @@ const (
 )
 
 var masterSecretLabel = []byte("master secret")
+var extendedMasterSecretLabel = []byte("extended master secret")
 var keyExpansionLabel = []byte("key expansion")
 var clientFinishedLabel = []byte("client finished")
 var serverFinishedLabel = []byte("server finished")
@@ -155,6 +156,16 @@ func masterFromPreMasterSecret(version uint16, suite *cipherSuite, preMasterSecr
 	copy(seed[len(clientRandom):], serverRandom)
 	masterSecret := make([]byte, masterSecretLength)
 	prfForVersion(version, suite)(masterSecret, preMasterSecret, masterSecretLabel, seed[0:])
+	return masterSecret
+}
+
+// extendedMasterFromPreMasterSecret generates the master secret from the
+// premaster secret. See https://tools.ietf.org/html/rfc7627#section-4
+func extendedMasterFromPreMasterSecret(version uint16, suite *cipherSuite, preMasterSecret, session_hash []byte) []byte {
+	seed := make([]byte, len(session_hash))
+	copy(seed, session_hash)
+	masterSecret := make([]byte, masterSecretLength)
+	prfForVersion(version, suite)(masterSecret, preMasterSecret, extendedMasterSecretLabel, seed[0:])
 	return masterSecret
 }
 

--- a/ztools/ztls/ztls_handshake.go
+++ b/ztools/ztls/ztls_handshake.go
@@ -29,16 +29,17 @@ type ClientHello struct {
 }
 
 type ServerHello struct {
-	Version             TLSVersion  `json:"version"`
-	Random              []byte      `json:"random"`
-	SessionID           []byte      `json:"session_id"`
-	CipherSuite         CipherSuite `json:"cipher_suite"`
-	CompressionMethod   uint8       `json:"compression_method"`
-	OcspStapling        bool        `json:"ocsp_stapling"`
-	TicketSupported     bool        `json:"ticket"`
-	SecureRenegotiation bool        `json:"secure_renegotiation"`
-	HeartbeatSupported  bool        `json:"heartbeat"`
-	ExtendedRandom      []byte      `json:"extended_random,omitempty"`
+	Version              TLSVersion  `json:"version"`
+	Random               []byte      `json:"random"`
+	SessionID            []byte      `json:"session_id"`
+	CipherSuite          CipherSuite `json:"cipher_suite"`
+	CompressionMethod    uint8       `json:"compression_method"`
+	OcspStapling         bool        `json:"ocsp_stapling"`
+	TicketSupported      bool        `json:"ticket"`
+	SecureRenegotiation  bool        `json:"secure_renegotiation"`
+	HeartbeatSupported   bool        `json:"heartbeat"`
+	ExtendedRandom       []byte      `json:"extended_random,omitempty"`
+	ExtendedMasterSecret bool        `json:"extended_master_secret"`
 }
 
 // SimpleCertificate holds a *x509.Certificate and a []byte for the certificate
@@ -185,6 +186,7 @@ func (m *serverHelloMsg) MakeLog() *ServerHello {
 		sh.ExtendedRandom = make([]byte, len(m.extendedRandom))
 		copy(sh.ExtendedRandom, m.extendedRandom)
 	}
+	sh.ExtendedMasterSecret = m.extendedMasterSecretEnabled
 	return sh
 }
 


### PR DESCRIPTION
Add extended master secret TLS extension through the use of the ``--tls-extended-master-secret'' command line flag. Tested against google.com's implementation IOT ensure accuracy in computation of master secret and ability to continue interaction once TLS handshake is complete.