### PR TITLE
Add --output-crypto-variables flag.

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func init() {
 
 	flag.BoolVar(&config.GatherSessionTicket, "tls-session-ticket", false, "Send support for TLS Session Tickets and output ticket if presented")
 	flag.BoolVar(&config.ExtendedMasterSecret, "tls-extended-master-secret", false, "Offer RFC 7627 Extended Master Secret extension")
-	flag.BoolVar(&config.TLSVerbose, "tls-verbose", false, "Add client_hello and key_material to JSON output")
+	flag.BoolVar(&config.TLSVerbose, "tls-verbose", false, "Add extra TLS information to JSON output (client hello, client KEX, key material, etc)")
 
 	flag.StringVar(&rootCAFileName, "ca-file", "", "List of trusted root certificate authorities in PEM format")
 	flag.IntVar(&config.GOMAXPROCS, "gomaxprocs", 3, "Set GOMAXPROCS (default 3)")

--- a/main.go
+++ b/main.go
@@ -112,6 +112,7 @@ func init() {
 
 	flag.BoolVar(&config.GatherSessionTicket, "tls-session-ticket", false, "Send support for TLS Session Tickets and output ticket if presented")
 	flag.BoolVar(&config.ExtendedMasterSecret, "tls-extended-master-secret", false, "Offer RFC 7627 Extended Master Secret extension")
+	flag.BoolVar(&config.OutputCryptoVariables, "output-crypto-variables", false, "Explicitly add crypto variables (PMS & MS) to JSON output")
 
 	flag.StringVar(&rootCAFileName, "ca-file", "", "List of trusted root certificate authorities in PEM format")
 	flag.IntVar(&config.GOMAXPROCS, "gomaxprocs", 3, "Set GOMAXPROCS (default 3)")

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func init() {
 
 	flag.BoolVar(&config.GatherSessionTicket, "tls-session-ticket", false, "Send support for TLS Session Tickets and output ticket if presented")
 	flag.BoolVar(&config.ExtendedMasterSecret, "tls-extended-master-secret", false, "Offer RFC 7627 Extended Master Secret extension")
-	flag.BoolVar(&config.LogMasterSecret, "log-master-secret", false, "Add premaster and master secrets to JSON output")
+	flag.BoolVar(&config.TLSVerbose, "tls-verbose", false, "Add client_hello and key_material to JSON output")
 
 	flag.StringVar(&rootCAFileName, "ca-file", "", "List of trusted root certificate authorities in PEM format")
 	flag.IntVar(&config.GOMAXPROCS, "gomaxprocs", 3, "Set GOMAXPROCS (default 3)")
@@ -127,6 +127,7 @@ func init() {
 	flag.BoolVar(&config.SSH.NegativeOne, "ssh-negative-one", false, "Set SSH DH kex value to -1 in the selected group")
 	flag.BoolVar(&config.Telnet, "telnet", false, "Read telnet banners")
 	flag.IntVar(&config.TelnetMaxSize, "telnet-max-size", 65536, "Max bytes to read for telnet banner")
+
 	flag.Parse()
 
 	// Validate Go Runtime config

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func init() {
 
 	flag.BoolVar(&config.GatherSessionTicket, "tls-session-ticket", false, "Send support for TLS Session Tickets and output ticket if presented")
 	flag.BoolVar(&config.ExtendedMasterSecret, "tls-extended-master-secret", false, "Offer RFC 7627 Extended Master Secret extension")
-	flag.BoolVar(&config.OutputCryptoVariables, "output-crypto-variables", false, "Explicitly add crypto variables (PMS & MS) to JSON output")
+	flag.BoolVar(&config.LogMasterSecret, "log-master-secret", false, "Add premaster and master secrets to JSON output")
 
 	flag.StringVar(&rootCAFileName, "ca-file", "", "List of trusted root certificate authorities in PEM format")
 	flag.IntVar(&config.GOMAXPROCS, "gomaxprocs", 3, "Set GOMAXPROCS (default 3)")

--- a/zgrab_schema.py
+++ b/zgrab_schema.py
@@ -206,9 +206,13 @@ zgrab_tls = SubRecord({
         "length":Integer(),
         "lifetime_hint":Long()
     }),
-    "crypto_variables":SubRecord({
-            "premaster_secret":Binary(),
-            "master_secret":Binary(),
+    "key_material":SubRecord({
+        "pre_master_secret":SubRecord({
+            "value":Binary()
+        }),
+        "master_secret":SubRecord({
+            "value":Binary()
+        }),
     }),
 })
 

--- a/zgrab_schema.py
+++ b/zgrab_schema.py
@@ -208,10 +208,59 @@ zgrab_tls = SubRecord({
     }),
     "key_material":SubRecord({
         "pre_master_secret":SubRecord({
-            "value":Binary()
+            "value":Binary(),
+            "length":Integer()
         }),
         "master_secret":SubRecord({
-            "value":Binary()
+            "value":Binary(),
+            "length":Integer()
+        }),
+    }),
+    "client_finished":SubRecord({
+        "verify_data":Binary()
+    }),
+    "client_key_exchange":SubRecord({
+        "dh_params":SubRecord({
+            "prime":SubRecord({
+                "value":Binary(),
+                "length":Integer()
+            }),
+            "generator":SubRecord({
+                "value":Binary(),
+                "length":Integer()
+            }),
+            "client_public":SubRecord({
+                "value":Binary(),
+                "length":Integer()
+            }),
+            "client_private":SubRecord({
+                "value":Binary(),
+                "length":Integer()
+            }),
+        }),
+        "ecdh_params":SubRecord({
+            "curve_id":SubRecord({
+                "name":String(),
+                "id":Integer()
+            }),
+            "client_public":SubRecord({
+                "x":SubRecord({
+                    "value":Binary(),
+                    "length":Integer()
+                }),
+                "y":SubRecord({
+                    "value":Binary(),
+                    "length":Integer()
+                }),
+            }),
+            "client_private":SubRecord({
+                "value":Binary(),
+                "length":Integer()
+            }),
+        }),
+        "rsa_params":SubRecord({
+            "length":Integer(),
+            "encrypted_pre_master_secret":Binary()
         }),
     }),
 })

--- a/zgrab_schema.py
+++ b/zgrab_schema.py
@@ -205,7 +205,11 @@ zgrab_tls = SubRecord({
         "value":Binary(),
         "length":Integer(),
         "lifetime_hint":Long()
-    })
+    }),
+    "crypto_variables":SubRecord({
+            "premaster_secret":Binary(),
+            "master_secret":Binary(),
+    }),
 })
 
 zgrab_base = Record({

--- a/zlib/config.go
+++ b/zlib/config.go
@@ -103,24 +103,24 @@ type Config struct {
 	Encoding string
 
 	// TLS
-	TLS                   bool
-	TLSVersion            uint16
-	Heartbleed            bool
-	RootCAPool            *x509.CertPool
-	DHEOnly               bool
-	ExportsOnly           bool
-	ExportsDHOnly         bool
-	FirefoxOnly           bool
-	FirefoxNoDHE          bool
-	ChromeOnly            bool
-	ChromeNoDHE           bool
-	SafariOnly            bool
-	SafariNoDHE           bool
-	NoSNI                 bool
-	TLSExtendedRandom     bool
-	GatherSessionTicket   bool
-	ExtendedMasterSecret  bool
-	OutputCryptoVariables bool
+	TLS                  bool
+	TLSVersion           uint16
+	Heartbleed           bool
+	RootCAPool           *x509.CertPool
+	DHEOnly              bool
+	ExportsOnly          bool
+	ExportsDHOnly        bool
+	FirefoxOnly          bool
+	FirefoxNoDHE         bool
+	ChromeOnly           bool
+	ChromeNoDHE          bool
+	SafariOnly           bool
+	SafariNoDHE          bool
+	NoSNI                bool
+	TLSExtendedRandom    bool
+	GatherSessionTicket  bool
+	ExtendedMasterSecret bool
+	LogMasterSecret      bool
 
 	// SSH
 	SSH SSHScanConfig

--- a/zlib/config.go
+++ b/zlib/config.go
@@ -120,7 +120,7 @@ type Config struct {
 	TLSExtendedRandom    bool
 	GatherSessionTicket  bool
 	ExtendedMasterSecret bool
-	LogMasterSecret      bool
+	TLSVerbose           bool
 
 	// SSH
 	SSH SSHScanConfig

--- a/zlib/config.go
+++ b/zlib/config.go
@@ -103,23 +103,24 @@ type Config struct {
 	Encoding string
 
 	// TLS
-	TLS                  bool
-	TLSVersion           uint16
-	Heartbleed           bool
-	RootCAPool           *x509.CertPool
-	DHEOnly              bool
-	ExportsOnly          bool
-	ExportsDHOnly        bool
-	FirefoxOnly          bool
-	FirefoxNoDHE         bool
-	ChromeOnly           bool
-	ChromeNoDHE          bool
-	SafariOnly           bool
-	SafariNoDHE          bool
-	NoSNI                bool
-	TLSExtendedRandom    bool
-	GatherSessionTicket  bool
-	ExtendedMasterSecret bool
+	TLS                   bool
+	TLSVersion            uint16
+	Heartbleed            bool
+	RootCAPool            *x509.CertPool
+	DHEOnly               bool
+	ExportsOnly           bool
+	ExportsDHOnly         bool
+	FirefoxOnly           bool
+	FirefoxNoDHE          bool
+	ChromeOnly            bool
+	ChromeNoDHE           bool
+	SafariOnly            bool
+	SafariNoDHE           bool
+	NoSNI                 bool
+	TLSExtendedRandom     bool
+	GatherSessionTicket   bool
+	ExtendedMasterSecret  bool
+	OutputCryptoVariables bool
 
 	// SSH
 	SSH SSHScanConfig

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -79,6 +79,7 @@ type Conn struct {
 	extendedRandom            bool
 	gatherSessionTicket       bool
 	offerExtendedMasterSecret bool
+	outputCryptoVariables     bool
 
 	domain string
 
@@ -157,6 +158,10 @@ func (c *Conn) SetGatherSessionTicket() {
 
 func (c *Conn) SetOfferExtendedMasterSecret() {
 	c.offerExtendedMasterSecret = true
+}
+
+func (c *Conn) SetOutputCryptoVariables() {
+	c.outputCryptoVariables = true
 }
 
 // Layer in the regular conn methods
@@ -486,6 +491,11 @@ func (c *Conn) TLSHandshake() error {
 		err = nil
 	}
 	hl := c.tlsConn.GetHandshakeLog()
+
+	if !c.outputCryptoVariables {
+		hl.CryptoVariables = nil
+	}
+
 	c.grabData.TLSHandshake = hl
 	return err
 }

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -495,6 +495,8 @@ func (c *Conn) TLSHandshake() error {
 	if !c.tlsVerbose {
 		hl.KeyMaterial = nil
 		hl.ClientHello = nil
+		hl.ClientFinished = nil
+		hl.ClientKeyExchange = nil
 	}
 
 	c.grabData.TLSHandshake = hl

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -79,7 +79,7 @@ type Conn struct {
 	extendedRandom            bool
 	gatherSessionTicket       bool
 	offerExtendedMasterSecret bool
-	logMasterSecret           bool
+	tlsVerbose                bool
 
 	domain string
 
@@ -160,8 +160,8 @@ func (c *Conn) SetOfferExtendedMasterSecret() {
 	c.offerExtendedMasterSecret = true
 }
 
-func (c *Conn) SetLogMasterSecret() {
-	c.logMasterSecret = true
+func (c *Conn) SetTLSVerbose() {
+	c.tlsVerbose = true
 }
 
 // Layer in the regular conn methods
@@ -492,8 +492,9 @@ func (c *Conn) TLSHandshake() error {
 	}
 	hl := c.tlsConn.GetHandshakeLog()
 
-	if !c.logMasterSecret {
-		hl.CryptoVariables = nil
+	if !c.tlsVerbose {
+		hl.KeyMaterial = nil
+		hl.ClientHello = nil
 	}
 
 	c.grabData.TLSHandshake = hl

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -79,7 +79,7 @@ type Conn struct {
 	extendedRandom            bool
 	gatherSessionTicket       bool
 	offerExtendedMasterSecret bool
-	outputCryptoVariables     bool
+	logMasterSecret           bool
 
 	domain string
 
@@ -160,8 +160,8 @@ func (c *Conn) SetOfferExtendedMasterSecret() {
 	c.offerExtendedMasterSecret = true
 }
 
-func (c *Conn) SetOutputCryptoVariables() {
-	c.outputCryptoVariables = true
+func (c *Conn) SetLogMasterSecret() {
+	c.logMasterSecret = true
 }
 
 // Layer in the regular conn methods
@@ -492,7 +492,7 @@ func (c *Conn) TLSHandshake() error {
 	}
 	hl := c.tlsConn.GetHandshakeLog()
 
-	if !c.outputCryptoVariables {
+	if !c.logMasterSecret {
 		hl.CryptoVariables = nil
 	}
 

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -133,8 +133,8 @@ func makeGrabber(config *Config) func(*Conn) error {
 		if config.ExtendedMasterSecret {
 			c.SetOfferExtendedMasterSecret()
 		}
-		if config.LogMasterSecret {
-			c.SetLogMasterSecret()
+		if config.TLSVerbose {
+			c.SetTLSVerbose()
 		}
 
 		if config.SSH.SSH {

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -133,6 +133,9 @@ func makeGrabber(config *Config) func(*Conn) error {
 		if config.ExtendedMasterSecret {
 			c.SetOfferExtendedMasterSecret()
 		}
+		if config.OutputCryptoVariables {
+			c.SetOutputCryptoVariables()
+		}
 
 		if config.SSH.SSH {
 			c.sshScan = &config.SSH

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -133,8 +133,8 @@ func makeGrabber(config *Config) func(*Conn) error {
 		if config.ExtendedMasterSecret {
 			c.SetOfferExtendedMasterSecret()
 		}
-		if config.OutputCryptoVariables {
-			c.SetOutputCryptoVariables()
+		if config.LogMasterSecret {
+			c.SetLogMasterSecret()
 		}
 
 		if config.SSH.SSH {

--- a/ztools/keys/ecdhe.go
+++ b/ztools/keys/ecdhe.go
@@ -24,12 +24,19 @@ import (
 // http://www.iana.org/assignments/tls-parameters/tls-parameters.xml#tls-parameters-8
 type TLSCurveID uint16
 
+type ECDHPrivateParams struct {
+	Value  []byte `json:"value,omitempty"`
+	Length int    `json:"length,omitempty"`
+}
+
 // ECDHParams stores elliptic-curve Diffie-Hellman paramters.At any point in
 // time, it is unlikely that both ServerPrivate and ClientPrivate will be non-nil.
 type ECDHParams struct {
-	TLSCurveID   TLSCurveID     `json:"curve_id,omitempty"`
-	Curve        elliptic.Curve `json:"-"`
-	ServerPublic *ECPoint       `json:"server_public,omitempty"`
+	TLSCurveID    TLSCurveID         `json:"curve_id,omitempty"`
+	Curve         elliptic.Curve     `json:"-"`
+	ServerPublic  *ECPoint           `json:"server_public,omitempty"`
+	ClientPublic  *ECPoint           `json:"client_public,omitempty"`
+	ClientPrivate *ECDHPrivateParams `json:"client_private,omitempty"`
 }
 
 // ECPoint represents an elliptic curve point and serializes nicely to JSON

--- a/ztools/keys/rsa.go
+++ b/ztools/keys/rsa.go
@@ -31,6 +31,11 @@ type auxRSAPublicKey struct {
 	Length   int    `json:"length"`
 }
 
+type RSAClientParams struct {
+	Length       uint16 `json:"length,omitempty"`
+	EncryptedPMS []byte `json:"encrypted_pre_master_secret,omitempty"`
+}
+
 // MarshalJSON implements the json.Marshal interface
 func (rp *RSAPublicKey) MarshalJSON() ([]byte, error) {
 	var aux auxRSAPublicKey

--- a/ztools/ztls/handshake_client.go
+++ b/ztools/ztls/handshake_client.go
@@ -506,6 +506,9 @@ func (hs *clientHandshakeState) doFullHandshake() error {
 		c.sendAlert(alertInternalError)
 		return err
 	}
+
+	c.handshakeLog.ClientKeyExchange = ckx.MakeLog(keyAgreement)
+
 	if ckx != nil {
 		hs.finishedHash.Write(ckx.marshal())
 		c.writeRecord(recordTypeHandshake, ckx.marshal())
@@ -724,6 +727,9 @@ func (hs *clientHandshakeState) sendFinished() error {
 	finished := new(finishedMsg)
 	finished.verifyData = hs.finishedHash.clientSum(hs.masterSecret)
 	hs.finishedHash.Write(finished.marshal())
+
+	c.handshakeLog.ClientFinished = finished.MakeLog()
+
 	c.writeRecord(recordTypeHandshake, finished.marshal())
 	return nil
 }

--- a/ztools/ztls/handshake_client.go
+++ b/ztools/ztls/handshake_client.go
@@ -250,7 +250,7 @@ func (c *Conn) clientHandshake() error {
 		c.handshakeLog.SessionTicket = hs.session.MakeLog()
 	}
 
-	c.handshakeLog.CryptoVariables = hs.MakeLog()
+	c.handshakeLog.KeyMaterial = hs.MakeLog()
 
 	if sessionCache != nil && hs.session != nil && session != hs.session {
 		sessionCache.Put(cacheKey, hs.session)

--- a/ztools/ztls/ztls_handshake.go
+++ b/ztools/ztls/ztls_handshake.go
@@ -79,11 +79,19 @@ type SessionTicket struct {
 	LifetimeHint uint32  `json:"lifetime_hint,omitempty"`
 }
 
-// CryptoVariables explicitly represent the cryptographic values negotiated by
+type MasterSecret struct {
+	Value []byte `json:"value,omitempty"`
+}
+
+type PreMasterSecret struct {
+	Value []byte `json:"value,omitempty"`
+}
+
+// KeyMaterial explicitly represent the cryptographic values negotiated by
 // the client and server
-type CryptoVariables struct {
-	MasterSecret    []uint8 `json:"master_secret,omitempty"`
-	PreMasterSecret []uint8 `json:"premaster_secret,omitempty"`
+type KeyMaterial struct {
+	MasterSecret    *MasterSecret    `json:"master_secret,omitempty"`
+	PreMasterSecret *PreMasterSecret `json:"pre_master_secret,omitempty"`
 }
 
 // ServerHandshake stores all of the messages sent by the server during a standard TLS Handshake.
@@ -95,7 +103,7 @@ type ServerHandshake struct {
 	ServerKeyExchange  *ServerKeyExchange `json:"server_key_exchange,omitempty"`
 	ServerFinished     *Finished          `json:"server_finished,omitempty"`
 	SessionTicket      *SessionTicket     `json:"session_ticket,omitempty"`
-	CryptoVariables    *CryptoVariables   `json:"crypto_variables,omitempty"`
+	KeyMaterial        *KeyMaterial       `json:"key_material,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshler interface
@@ -289,11 +297,16 @@ func (m *ClientSessionState) MakeLog() *SessionTicket {
 	return st
 }
 
-func (m *clientHandshakeState) MakeLog() *CryptoVariables {
-	cv := new(CryptoVariables)
-	cv.MasterSecret = make([]byte, len(m.masterSecret))
-	copy(cv.MasterSecret, m.masterSecret)
-	cv.PreMasterSecret = make([]byte, len(m.preMasterSecret))
-	copy(cv.PreMasterSecret, m.preMasterSecret)
-	return cv
+func (m *clientHandshakeState) MakeLog() *KeyMaterial {
+	keymat := new(KeyMaterial)
+	keymat.MasterSecret = new(MasterSecret)
+	keymat.PreMasterSecret = new(PreMasterSecret)
+
+	keymat.MasterSecret.Value = make([]byte, len(m.masterSecret))
+	copy(keymat.MasterSecret.Value, m.masterSecret)
+
+	keymat.PreMasterSecret.Value = make([]byte, len(m.preMasterSecret))
+	copy(keymat.PreMasterSecret.Value, m.preMasterSecret)
+
+	return keymat
 }

--- a/ztools/ztls/ztls_handshake.go
+++ b/ztools/ztls/ztls_handshake.go
@@ -79,6 +79,13 @@ type SessionTicket struct {
 	LifetimeHint uint32  `json:"lifetime_hint,omitempty"`
 }
 
+// CryptoVariables explicitly represent the cryptographic values negotiated by
+// the client and server
+type CryptoVariables struct {
+	MasterSecret    []uint8 `json:"master_secret,omitempty"`
+	PreMasterSecret []uint8 `json:"premaster_secret,omitempty"`
+}
+
 // ServerHandshake stores all of the messages sent by the server during a standard TLS Handshake.
 // It implements zgrab.EventData interface
 type ServerHandshake struct {
@@ -88,6 +95,7 @@ type ServerHandshake struct {
 	ServerKeyExchange  *ServerKeyExchange `json:"server_key_exchange,omitempty"`
 	ServerFinished     *Finished          `json:"server_finished,omitempty"`
 	SessionTicket      *SessionTicket     `json:"session_ticket,omitempty"`
+	CryptoVariables    *CryptoVariables   `json:"crypto_variables,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshler interface
@@ -279,4 +287,13 @@ func (m *ClientSessionState) MakeLog() *SessionTicket {
 	copy(st.Value, m.sessionTicket)
 	st.LifetimeHint = m.lifetimeHint
 	return st
+}
+
+func (m *clientHandshakeState) MakeLog() *CryptoVariables {
+	cv := new(CryptoVariables)
+	cv.MasterSecret = make([]byte, len(m.masterSecret))
+	copy(cv.MasterSecret, m.masterSecret)
+	cv.PreMasterSecret = make([]byte, len(m.preMasterSecret))
+	copy(cv.PreMasterSecret, m.preMasterSecret)
+	return cv
 }

--- a/ztools/ztls/ztls_ka.go
+++ b/ztools/ztls/ztls_ka.go
@@ -64,6 +64,26 @@ func (ka *ecdheKeyAgreement) ECDHParams() *keys.ECDHParams {
 	return out
 }
 
+func (ka *ecdheKeyAgreement) ClientECDHParams() *keys.ECDHParams {
+	out := new(keys.ECDHParams)
+	out.TLSCurveID = keys.TLSCurveID(ka.curveID)
+	out.ClientPublic = &keys.ECPoint{}
+	if ka.x != nil {
+		out.ClientPublic.X = new(big.Int)
+		out.ClientPublic.X.Set(ka.clientX)
+	}
+	if ka.y != nil {
+		out.ClientPublic.Y = new(big.Int)
+		out.ClientPublic.Y.Set(ka.clientY)
+	}
+
+	out.ClientPrivate = new(keys.ECDHPrivateParams)
+	out.ClientPrivate.Length = len(ka.clientPrivKey)
+	out.ClientPrivate.Value = make([]byte, len(ka.clientPrivKey))
+	copy(out.ClientPrivate.Value, ka.clientPrivKey)
+	return out
+}
+
 func (ka *dheKeyAgreement) DHParams() *keys.DHParams {
 	out := new(keys.DHParams)
 	if ka.p != nil {
@@ -74,6 +94,23 @@ func (ka *dheKeyAgreement) DHParams() *keys.DHParams {
 	}
 	if ka.yServer != nil {
 		out.ServerPublic = new(big.Int).Set(ka.yServer)
+	}
+	return out
+}
+
+func (ka *dheKeyAgreement) ClientDHParams() *keys.DHParams {
+	out := new(keys.DHParams)
+	if ka.p != nil {
+		out.Prime = new(big.Int).Set(ka.p)
+	}
+	if ka.g != nil {
+		out.Generator = new(big.Int).Set(ka.g)
+	}
+	if ka.yClient != nil {
+		out.ClientPublic = new(big.Int).Set(ka.yClient)
+	}
+	if ka.xOurs != nil {
+		out.ClientPrivate = new(big.Int).Set(ka.xOurs)
 	}
 	return out
 }


### PR DESCRIPTION
Cmd flag adds premaster secret and master secret to the JSON output of
the ZGrab targets IOT avoid re-computation in post-processing and
analysis.