### PR TITLE
Toward X.509 certificates that json.Unmarshal

### DIFF
--- a/ztools/x509/json_test.go
+++ b/ztools/x509/json_test.go
@@ -53,3 +53,12 @@ func (s *JSONSuite) TestEncodeCertificate(c *C) {
 	c.Assert(err, IsNil)
 	fmt.Println(string(b))
 }
+
+func (s *JSONSuite) TestDecodeCertificate(c *C) {
+	b, errMarshal := json.Marshal(s.parsedCert)
+	c.Assert(errMarshal, IsNil)
+	cert := new(Certificate)
+	errUnmarshal := json.Unmarshal(b, cert)
+	c.Assert(errUnmarshal, IsNil)
+	c.Check(cert, DeepEquals, s.parsedCert)
+}

--- a/ztools/x509/pkix/pkix.go
+++ b/ztools/x509/pkix/pkix.go
@@ -27,8 +27,8 @@ type RelativeDistinguishedNameSET []AttributeTypeAndValue
 // AttributeTypeAndValue mirrors the ASN.1 structure of the same name in
 // http://tools.ietf.org/html/rfc5280#section-4.1.2.4
 type AttributeTypeAndValue struct {
-	Type  asn1.ObjectIdentifier `json:"type"`
-	Value interface{}           `json:"value"`
+	Type  asn1.ObjectIdentifier
+	Value interface{}
 }
 
 // AttributeTypeAndValueSET represents a set of ASN.1 sequences of


### PR DESCRIPTION
This is to track progress towards implementing the missing json.Unmarshal functions in the X.509 library, which is required to have a decent implemention of json.Unmarshal within ztls.

This should not be merged yet.