### PR TITLE
only parse known headers

### DIFF
--- a/ztools/http/header.go
+++ b/ztools/http/header.go
@@ -78,11 +78,27 @@ func (h Header) WriteSubset(w io.Writer, exclude map[string]bool) error {
 // canonical key for "accept-encoding" is "Accept-Encoding".
 func CanonicalHeaderKey(s string) string { return textproto.CanonicalMIMEHeaderKey(s) }
 
+func FormatHeaderName(s string) string {
+	return strings.Replace(strings.ToLower(s), "-", "_", 30)
+}
+
+type UnknownHeader struct {
+	Key    string   `json:"key,omitempty"`
+	Values []string `json:"value,omitempty"`
+}
+
 // Custom JSON Marshaller to comply with snake_case header names
 func (h Header) MarshalJSON() ([]byte, error) {
 	headerMap := make(map[string]interface{})
 	for k, v := range h {
-		headerMap[strings.Replace(strings.ToLower(k), "-", "_", 10)] = v
+		// Need to special-case unknown header object, since it's not a true header (aka map[string][]string)
+		if k == "Unknown" && len(v) > 0 {
+			var unknownHeader []UnknownHeader
+			json.Unmarshal([]byte(v[0]), &unknownHeader)
+			headerMap[FormatHeaderName(k)] = unknownHeader
+		} else {
+			headerMap[FormatHeaderName(k)] = v
+		}
 	}
 
 	return json.Marshal(headerMap)

--- a/ztools/http/response.go
+++ b/ztools/http/response.go
@@ -8,6 +8,7 @@ package http
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/textproto"
@@ -17,9 +18,58 @@ import (
 )
 
 var respExcludeHeader = map[string]bool{
-	"Content-Length":    true,
-	"Transfer-Encoding": true,
-	"Trailer":           true,
+	"Trailer": true,
+}
+
+var knownHeaders = map[string]bool{
+	"access_control_allow_origin": true,
+	"accept_patch":                true,
+	"accept_ranges":               true,
+	"age":                         true,
+	"allow":                       true,
+	"cache_control":               true,
+	"connection":                  true,
+	"content_disposition":         true,
+	"content_encoding":            true,
+	"content_language":            true,
+	"content_length":              true,
+	"content_location":            true,
+	"content_md5":                 true,
+	"content_range":               true,
+	"content_type":                true,
+	"expires":                     true,
+	"last_modified":               true,
+	"link":                        true,
+	"location":                    true,
+	"p3p":                         true,
+	"pragma":                      true,
+	"proxy_agent":                 true,
+	"proxy_authenticate":          true,
+	"public_key_pins":             true,
+	"refresh":                     true,
+	"retry_after":                 true,
+	"server":                      true,
+	"set_cookie":                  true,
+	"status":                      true,
+	"strict_transport_security":   true,
+	"trailer":                     true,
+	"transfer_encoding":           true,
+	"upgrade":                     true,
+	"vary":                        true,
+	"via":                         true,
+	"warning":                     true,
+	"www_authenticate":            true,
+	"x_frame_options":             true,
+	"x_xss_protection":            true,
+	"content_security_policy":     true,
+	"x_content_security_policy":   true,
+	"x_webkit_csp":                true,
+	"x_content_type_options":      true,
+	"x_powered_by":                true,
+	"x_ua_compatible":             true,
+	"x_content_duration":          true,
+	"x_real_ip":                   true,
+	"x_forwarded_for":             true,
 }
 
 // Response represents the response from an HTTP request.
@@ -143,7 +193,11 @@ func ReadResponse(r *bufio.Reader, req *Request) (resp *Response, err error) {
 	if err != nil {
 		return nil, err
 	}
+
 	resp.Headers = Header(mimeHeader)
+
+	//remove unknown headers
+	filterHeaders(resp.Headers)
 
 	fixPragmaCacheControl(resp.Headers)
 
@@ -163,6 +217,25 @@ func fixPragmaCacheControl(header Header) {
 	if hp, ok := header["Pragma"]; ok && len(hp) > 0 && hp[0] == "no-cache" {
 		if _, presentcc := header["Cache-Control"]; !presentcc {
 			header["Cache-Control"] = []string{"no-cache"}
+		}
+	}
+}
+
+func filterHeaders(h Header) {
+	var unknownHeaders []UnknownHeader
+	for header, values := range h {
+		if _, ok := knownHeaders[FormatHeaderName(header)]; !ok {
+			unk := UnknownHeader{
+				Key:    FormatHeaderName(header),
+				Values: values,
+			}
+			unknownHeaders = append(unknownHeaders, unk)
+			h.Del(header)
+		}
+	}
+	if len(unknownHeaders) > 0 {
+		if unknownHeaderStr, err := json.Marshal(unknownHeaders); err == nil {
+			h["Unknown"] = []string{string(unknownHeaderStr)}
 		}
 	}
 }


### PR DESCRIPTION
@zakird @dadrian 

Reverts to the old behaviour of only parsing a white-listed set of known headers. All other headers go under the "unknown" header field.

Example query:
`echo "88.85.84.122" | zgrab --port 80 --http="/" --http-max-redirects=2`

Result:
```
{
  "ip": "88.85.84.122",
  "timestamp": "2016-03-22T10:15:35-05:00",
  "data": {
    "http": {
      "response": {
        "status_line": "200 OK",
        "status_code": 200,
        "protocol": {
          "name": "HTTP\/1.1",
          "major": 1,
          "minor": 1
        },
        "headers": {
          "cache_control": [
            "no-cache, must-revalidate"
          ],
          "connection": [
            "keep-alive"
          ],
          "content_type": [
            "text\/html; charset=\"UTF-8\""
          ],
          "expires": [
            "Mon, 26 Jul 1997 05:00:00 GMT"
          ],
          "last_modified": [
            "Tue, 22 Mar 2016 15:15:11 GMT"
          ],
          "pragma": [
            "no-cache"
          ],
          "server": [
            "nginx\/1.8.0"
          ],
          "set_cookie": [
            "lang=0; path=\/",
            "__sid=ru_27; path=\/",
            "token=97768c01e7150ead57490e4e2f08eee2; path=\/; domain=88.85.84.122:80"
          ],
          "unknown": [
            {
              "key": "accept_charset",
              "value": [
                "UTF-8"
              ]
            },
            {
              "key": "date",
              "value": [
                "Tue, 22 Mar 2016 15:15:11 GMT"
              ]
            }
          ],
          "vary": [
            "Accept-Encoding"
          ],
          "x_powered_by": [
            "PHP\/5.4.16"
          ]
        },
        "body": "<!DOCTYPE html PUBLIC \"-\/\/W3C\/\/DTD XHTML 1.0 Transitional\/\/EN\" \"http:\/\/www.w3.org\/TR\/xhtml1\/DTD\/xhtml1-transitional.dtd\"><!-- Time: 0.0068581104278564 -->\n<html xmlns=\"http:\/\/www.w3.org\/1999\/xhtml\">\n    <head>\n        <script>var IsMe = false;<\/script>\n                <link rel=\"icon\" href=\"\/empty.ico\" type=\"image\/x-icon\"\/><link rel=\"shortcut icon\" href=\"\/empty.ico\" type=\"image\/x-icon\"\/><meta http-equiv=\"content-type\" content=\"text\/html; charset=utf-8\" \/><title><\/title><meta name=\"description\" content=\"\"\/><meta  name=\"keywords\" content=\"\"\/><base href=\"http:\/\/88.85.84.122:80\/form\"><\/base>        \n    <\/head>\n    <body>\n            <\/body>\n<\/html> ",
        "body_sha256": "Awv8h+HokM60fdiru6EtECKZJr9wpK6V1wL8jLTnlYw=",
        "content_length": -1,
        "transfer_encoding": [
          "chunked"
        ],
        "request": {
          "url": {
            "scheme": "http",
            "host": "88.85.84.122:80"
          },
          "method": "GET",
          "host": "88.85.84.122:80"
        }
      }
    }
  }
}
```