### PR TITLE
Fix confusing JSON output in server_hello.

### DIFF
--- a/ztools/ztls/handshake_client.go
+++ b/ztools/ztls/handshake_client.go
@@ -165,7 +165,7 @@ func (c *Conn) clientHandshake() error {
 		c.sendAlert(alertUnexpectedMessage)
 		return unexpectedMessageError(serverHello, msg)
 	}
-	c.handshakeLog.ServerHello = serverHello.MakeLog()
+	c.handshakeLog.ServerHello = serverHello.MakeLog(c.config)
 
 	if serverHello.heartbeatEnabled {
 		c.heartbeat = true


### PR DESCRIPTION
* Fixes Issue #117
    * Extended master secret and session ticket ext show as 'not
        supported' if not offered
* Patch is overly complicated compared to others b/c empty/default
    boolean value is false
    * Using 'omitempty' would mean non-supporting servers would not
        have field when offered