### PR TITLE
add pdu length field to s7 request

### DIFF
--- a/ztools/scada/siemens/s7.go
+++ b/ztools/scada/siemens/s7.go
@@ -163,7 +163,8 @@ func makeNegotiatePDUParamBytes() (bytes []byte) {
 	bytes = append(bytes, uint16BytesHolder...) // min # of parallel jobs
 	binary.BigEndian.PutUint16(uint16BytesHolder, 0x01)
 	bytes = append(bytes, uint16BytesHolder...) // max # of parallel jobs
-
+	binary.BigEndian.PutUint16(uint16BytesHolder, 0x01e0)
+	bytes = append(bytes, uint16BytesHolder...) // pdu length
 	return bytes
 }
 


### PR DESCRIPTION
@zakird 
FYI - going to go ahead and auto-merge. While re-visiting S7 protocol, I noticed that adding this field increases the number of detected S7 devices without losing any devices that are already  being detected. 