### PR TITLE
don't hold on to idle connections

### DIFF
--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -167,7 +167,7 @@ func makeHTTPGrabber(config *Config, grabData GrabData) func(string) error {
 			Dial:                makeNetDialer(config),
 			DisableKeepAlives:   false,
 			DisableCompression:  false,
-			MaxIdleConnsPerHost: 1,
+			MaxIdleConnsPerHost: -1,
 			TLSClientConfig:     tlsConfig,
 		}
 


### PR DESCRIPTION
@zakird 

This seems to fix the main memory leak error and hopefully will resolve the issues we were seeing for the HTTP scans. Basically, we were caching every connection and never purging. The other thing is that we never really utilized the cache, so this change should not noticeably affect performance. 