### PR TITLE
Zzma/handle only domain inputs

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ func init() {
 	flag.StringVar(&inputFileName, "input-file", "-", "Input filename, use - for stdin")
 	flag.StringVar(&metadataFileName, "metadata-file", "-", "File to record banner-grab metadata, use - for stdout")
 	flag.StringVar(&logFileName, "log-file", "-", "File to log to, use - for stderr")
+	flag.BoolVar(&config.LookupDomain, "lookup-domain", false, "Input contains only domain names")
 	flag.StringVar(&interfaceName, "interface", "", "Network interface to send on")
 	flag.UintVar(&portFlag, "port", 80, "Port to grab on")
 	flag.UintVar(&timeout, "timeout", 10, "Set connection timeout in seconds")
@@ -345,7 +346,7 @@ func init() {
 
 func main() {
 	runtime.GOMAXPROCS(config.GOMAXPROCS)
-	decoder := zlib.NewGrabTargetDecoder(inputFile)
+	decoder := zlib.NewGrabTargetDecoder(inputFile, config.LookupDomain)
 	marshaler := zlib.NewGrabMarshaler()
 	worker := zlib.NewGrabWorker(&config)
 	start := time.Now()

--- a/zlib/config.go
+++ b/zlib/config.go
@@ -99,6 +99,9 @@ type Config struct {
 	Senders            uint
 	ConnectionsPerHost uint
 
+	// DNS
+	LookupDomain bool
+
 	// Encoding
 	Encoding string
 

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -530,6 +530,7 @@ func GrabBanner(config *Config, target *GrabTarget) *Grab {
 		} else {
 			rhost = net.JoinHostPort(target.Addr.String(), port)
 		}
+		rhost += config.HTTP.Endpoint
 
 		err := httpGrabber(rhost)
 

--- a/ztools/processing/input.go
+++ b/ztools/processing/input.go
@@ -15,6 +15,7 @@
 package processing
 
 import (
+	"github.com/zmap/zgrab/ztools/zlog"
 	"io"
 	"sync"
 )
@@ -83,6 +84,8 @@ func Process(in Decoder, out io.Writer, w Worker, m Marshaler, workers uint) {
 		obj, err := in.DecodeNext()
 		if err == io.EOF {
 			break
+		} else if err != nil {
+			zlog.Error(err)
 		}
 		processQueue <- obj
 	}


### PR DESCRIPTION
@zakird @dadrian 

Adding a new command line option "--lookup-domain" that expects a list of domain names and will look them up. Currently only works for HTTP, but can be expanded to other protocols, if necessary. This is the stuff that Ben is looking for. 

Question - should I make the name for this option have an "http" prefix? Do we envision doing DNS lookups for other domains? 