### PR TITLE
Use zmap/rc2 instead of dadrian/rc2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go:
 - 1.5.2
 before_install:
 - go get gopkg.in/check.v1
-- go get github.com/dadrian/rc2
+- go get github.com/zmap/rc2
 - go get github.com/axw/gocov/gocov
 - go get github.com/mattn/goveralls
 - go get golang.org/x/tools/cmd/cover

--- a/ztools/ztls/cipher_suites.go
+++ b/ztools/ztls/cipher_suites.go
@@ -16,7 +16,7 @@ import (
 	"crypto/sha512"
 	"hash"
 
-	"github.com/dadrian/rc2"
+	"github.com/zmap/rc2"
 	"github.com/zmap/zgrab/ztools/x509"
 )
 


### PR DESCRIPTION
Longer term, we should vendor all of our dependencies.

Fixes #103