### PR TITLE
add alt_svc and alternate_protocol as known headers

### DIFF
--- a/ztools/http/response.go
+++ b/ztools/http/response.go
@@ -27,6 +27,8 @@ var knownHeaders = map[string]bool{
 	"accept_ranges":               true,
 	"age":                         true,
 	"allow":                       true,
+	"alt_svc":                     true,
+	"alternate_protocol":          true,
 	"cache_control":               true,
 	"connection":                  true,
 	"content_disposition":         true,


### PR DESCRIPTION
Headers for issue: https://github.com/zmap/zgrab/issues/111

Tested on google, which returns: 
```
"headers":{"alt_svc":["quic=\":443\"; ma=2592000; v=\"34,33,32,31,30,29,28,27,26,25\""],"alternate_protocol":["443:quic"],....
```