### PR TITLE
setup TLSConfig whenever redirecting

### DIFF
--- a/main.go
+++ b/main.go
@@ -184,7 +184,7 @@ func init() {
 		config.TLS = true
 	}
 
-	if config.TLS {
+	if config.TLS || config.HTTP.MaxRedirects > 0 {
 
 		switch tv {
 		case "SSLV3", "SSLV30", "SSLV3.0":

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -142,7 +142,7 @@ func makeHTTPGrabber(config *Config, grabData GrabData) func(string, string) err
 	g := func(host, endpoint string) error {
 
 		var tlsConfig *ztls.Config
-		if config.TLS {
+		if config.TLS || config.HTTP.MaxRedirects > 0 {
 			tlsConfig = new(ztls.Config)
 			tlsConfig.InsecureSkipVerify = true
 			tlsConfig.MinVersion = ztls.VersionSSL30


### PR DESCRIPTION
@dadrian @zakird 

Need to set up the TLSConfig whenever there are redirects, in case it's a http --> https redirect. HTTPS redirects were previously using a default TLSConfig that was automatically failing on validation errors. 