### PR TITLE
Zzma/set http host header when domain present

### DIFF
--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -209,7 +209,7 @@ func makeHTTPGrabber(config *Config, grabData GrabData) func(string, string, str
 		client.UserAgent = config.HTTP.UserAgent
 		client.CheckRedirect = func(req *http.Request, res *http.Response, via []*http.Request) error {
 			grabData.HTTP.RedirectResponseChain = append(grabData.HTTP.RedirectResponseChain, res)
-			if str, err := util.ReadString(res.Body, config.HTTP.MaxSize*1000); err != nil {
+			if str, err := util.ReadString(res.Body, config.HTTP.MaxSize*1024); err != nil {
 				return err
 			} else {
 				res.BodyText = str
@@ -237,7 +237,6 @@ func makeHTTPGrabber(config *Config, grabData GrabData) func(string, string, str
 		}
 
 		var resp *http.Response
-
 		switch config.HTTP.Method {
 		case "GET":
 			resp, err = client.GetWithHost(fullURL, httpHost)
@@ -254,7 +253,7 @@ func makeHTTPGrabber(config *Config, grabData GrabData) func(string, string, str
 
 		grabData.HTTP.Response = resp
 
-		if str, err := util.ReadString(resp.Body, config.HTTP.MaxSize*1000); err != nil {
+		if str, err := util.ReadString(resp.Body, config.HTTP.MaxSize*1024); err != nil {
 			return err
 		} else {
 			grabData.HTTP.Response.BodyText = str

--- a/zlib/grabber_test.go
+++ b/zlib/grabber_test.go
@@ -1,0 +1,88 @@
+package zlib_test
+
+import (
+	"fmt"
+	. "github.com/zmap/zgrab/ztools/http"
+	"github.com/zmap/zgrab/ztools/http/httptest"
+	"net"
+	"testing"
+	"net/url"
+	"strings"
+	"strconv"
+	"github.com/zmap/zgrab/zlib"
+	"github.com/zmap/zgrab/ztools/ztls"
+	"github.com/zmap/zgrab/ztools/zlog"
+	"time"
+	"os"
+)
+
+const TEST_SERVER_BODY = "Great Success!"
+
+func TestHTTP(t *testing.T) {
+	ts := httptest.NewServer(HandlerFunc(func(w ResponseWriter, r *Request) {
+		w.Header().Set("Last-Modified", "sometime")
+		fmt.Fprintf(w, TEST_SERVER_BODY)
+		if r.Host != "localhost" {
+			t.Errorf("Wrong Host - expected: %s, got: %s", "localhost", r.Host)
+		}
+		if r.Method != "GET" {
+			t.Errorf("Wrong Method - expected: %s, got: %s", "GET", r.Method)
+		}
+		if r.Protocol.Name != "HTTP/1.1" {
+			t.Errorf("Wrong Protocol - expected: %s, got: %s", "HTTP/1.1", r.Protocol.Name)
+		}
+		if len(r.Headers) != 2 || r.Headers.Get("User-Agent") != "test UA" || r.Headers.Get("Accept-Encoding") != "gzip" {
+			t.Errorf("Wrong headers: Expected User-Agent and Accept-Encoding, Got %s", r.Headers)
+		}
+	}))
+	defer ts.Close()
+
+	var addr net.IP
+	var port uint16
+	if u, err := url.Parse(ts.URL); err != nil {
+		t.Errorf("Invalid URL %s", ts.URL)
+	} else {
+		hostSlice := strings.Split(u.Host, ":")
+		addr = net.ParseIP(hostSlice[0])
+		if testPort, err := strconv.ParseUint(hostSlice[1], 10, 16); err != nil {
+			t.Errorf("Unable to parse port %s", hostSlice[1])
+		} else {
+			port = uint16(testPort)
+		}
+
+	}
+
+	config := &zlib.Config{
+		Port: port,
+		Timeout: time.Duration(3) * time.Second,
+		TLS: false,
+		TLSVersion: ztls.VersionTLS12,
+		Senders: 1,
+		ConnectionsPerHost: 1,
+		HTTP: zlib.HTTPConfig{
+			Endpoint: "/",
+			Method: "GET",
+			UserAgent: "test UA",
+			MaxSize: 256,
+			MaxRedirects: 0,
+		},
+		ErrorLog: zlog.New(os.Stderr, "banner-grab"),
+		GOMAXPROCS: 3,
+	}
+
+	target := &zlib.GrabTarget{
+		Addr: addr,
+		Domain: "localhost",
+	}
+
+	grab := zlib.GrabBanner(config, target)
+	httpResponse := grab.Data.HTTP.Response
+	if httpResponse.Status != "200 OK" {
+		t.Errorf("Unable to load page: Expected: 200 OK, got: %s", httpResponse.Status)
+	}
+	if httpResponse.BodyText != TEST_SERVER_BODY {
+		t.Errorf("Unexpected HTTP response body")
+	}
+}
+
+// TODO: add test for more complex HTTP behavior/options

--- a/ztools/http/client.go
+++ b/ztools/http/client.go
@@ -190,7 +190,11 @@ func Get(url string) (r *Response, err error) {
 //
 // Caller should close r.Body when done reading from it.
 func (c *Client) Get(url string) (r *Response, err error) {
-	req, err := NewRequest("GET", url, nil)
+	return c.GetWithHost(url, "")
+}
+
+func (c *Client) GetWithHost(url, host string) (r *Response, err error) {
+	req, err := NewRequestWithHost("GET", url, host, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +377,11 @@ func Head(url string) (r *Response, err error) {
 //    303 (See Other)
 //    307 (Temporary Redirect)
 func (c *Client) Head(url string) (r *Response, err error) {
-	req, err := NewRequest("HEAD", url, nil)
+	return c.HeadWithHost(url, "")
+}
+
+func (c *Client) HeadWithHost(url, host string) (r *Response, err error) {
+	req, err := NewRequestWithHost("HEAD", url, host, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ztools/http/request.go
+++ b/ztools/http/request.go
@@ -437,12 +437,21 @@ func ParseHTTPVersion(vers string) (major, minor int, ok bool) {
 	return major, minor, true
 }
 
-// NewRequest returns a new Request given a method, URL, and optional body.
 func NewRequest(method, urlStr string, body io.Reader) (*Request, error) {
+	return NewRequestWithHost(method, urlStr, "", body)
+}
+
+// NewRequest returns a new Request given a method, URL, and optional body.
+func NewRequestWithHost(method, urlStr, host string, body io.Reader) (*Request, error) {
 	u, err := url.Parse(urlStr)
 	if err != nil {
 		return nil, err
 	}
+
+	if host == "" {
+		host = u.Host
+	}
+
 	rc, ok := body.(io.ReadCloser)
 	if !ok && body != nil {
 		rc = ioutil.NopCloser(body)
@@ -457,7 +466,7 @@ func NewRequest(method, urlStr string, body io.Reader) (*Request, error) {
 		},
 		Headers: make(Header),
 		Body:    rc,
-		Host:    u.Host,
+		Host:    host,
 	}
 	if body != nil {
 		switch v := body.(type) {


### PR DESCRIPTION
@zakird @dadrian 

When doing HTTP grabs where an IP, domain are provided, create a connection to <IP>, but set the HTTP host as <domain>. As part of this, I added a functional test that we can use to test other existing/future zgrab logic. 

