### PR TITLE
Convert to (x509.AugmentedECDSA), not (ecdsa.PublicKey)

### DIFF
--- a/ztools/ztls/key_agreement.go
+++ b/ztools/ztls/key_agreement.go
@@ -410,9 +410,10 @@ func (ka *signedKeyAgreement) verifyParameters(config *Config, clientHello *clie
 
 	switch ka.sigType {
 	case signatureECDSA:
-		pubKey, ok := cert.PublicKey.(*ecdsa.PublicKey)
+		augECDSA, ok := cert.PublicKey.(*x509.AugmentedECDSA)
+		pubKey := augECDSA.Pub
 		if !ok {
-			return errors.New("ECDHE ECDSA requires a ECDSA server public key")
+			return errors.New("ECDHE ECDSA: could not covert cert.PublicKey to x509.AugmentedECDSA")
 		}
 		ecdsaSig := new(ecdsaSignature)
 		if _, err := asn1.Unmarshal(sig, ecdsaSig); err != nil {


### PR DESCRIPTION
Newly introduced AugmentedECDSA broke key agreement for my code. Here's the commit, that fixed the issue