### PR TITLE
return a partial response even when HTTP ultimately fails

### DIFF
--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -286,12 +286,12 @@ func makeHTTPGrabber(config *Config, grabData GrabData) func(string, string, str
 			zlog.Fatalf("Bad HTTP Method: %s. Valid options are: GET, HEAD.", config.HTTP.Method)
 		}
 
+		grabData.HTTP.Response = resp
+
 		if err != nil {
 			config.ErrorLog.Errorf("Could not connect to remote host %s: %s", fullURL, err.Error())
 			return err
 		}
-
-		grabData.HTTP.Response = resp
 
 		if str, err := util.ReadString(resp.Body, config.HTTP.MaxSize*1024); err != nil {
 			return err

--- a/ztools/http/response.go
+++ b/ztools/http/response.go
@@ -167,11 +167,11 @@ func ReadResponse(r *bufio.Reader, req *Request) (resp *Response, err error) {
 		if err == io.EOF {
 			err = io.ErrUnexpectedEOF
 		}
-		return nil, err
+		return resp, err
 	}
 	f := strings.SplitN(line, " ", 3)
 	if len(f) < 2 {
-		return nil, &badStringError{"malformed HTTP response", line}
+		return resp, &badStringError{"malformed HTTP response", line}
 	}
 	reasonPhrase := ""
 	if len(f) > 2 {
@@ -180,20 +180,20 @@ func ReadResponse(r *bufio.Reader, req *Request) (resp *Response, err error) {
 	resp.Status = f[1] + " " + reasonPhrase
 	resp.StatusCode, err = strconv.Atoi(f[1])
 	if err != nil {
-		return nil, &badStringError{"malformed HTTP status code", f[1]}
+		return resp, &badStringError{"malformed HTTP status code", f[1]}
 	}
 
 	resp.Protocol = *(new(Protocol))
 	resp.Protocol.Name = f[0]
 	var ok bool
 	if resp.Protocol.Major, resp.Protocol.Minor, ok = ParseHTTPVersion(resp.Protocol.Name); !ok {
-		return nil, &badStringError{"malformed HTTP version", resp.Protocol.Name}
+		return resp, &badStringError{"malformed HTTP version", resp.Protocol.Name}
 	}
 
 	// Parse the response headers.
 	mimeHeader, err := tp.ReadMIMEHeader()
 	if err != nil {
-		return nil, err
+		return resp, err
 	}
 
 	resp.Headers = Header(mimeHeader)
@@ -205,7 +205,7 @@ func ReadResponse(r *bufio.Reader, req *Request) (resp *Response, err error) {
 
 	err = readTransfer(resp, r)
 	if err != nil {
-		return nil, err
+		return resp, err
 	}
 
 	return resp, nil


### PR DESCRIPTION
@zakird @dadrian 

This is for issue https://github.com/zmap/zgrab/issues/190. Instead of returning `nil` when HTTP fails, return an incomplete HTTP data object that includes TLS info. 

Before: 
```
$ echo "52.50.169.99" | ./zgrab --port 443 --tls --http="/"
{"ip":"52.50.169.99","timestamp":"2016-10-05T23:30:24Z","data":{"http":{}},"error":"Get https://52.50.169.99:443/: unexpected EOF"}
```
After:
```
$ echo "52.50.169.99" | ./zgrab --port 443 --tls --http="/"
{
  "ip": "52.50.169.99",
  "timestamp": "2016-10-06T08:55:49-05:00",
  "data": {
    "http": {
      "response": {
        "protocol": {
          
        },
        "request": {
          "url": {
            "scheme": "https",
            "host": "52.50.169.99:443",
            "path": "\/"
          },
          "method": "GET",
          "headers": {
            "user_agent": [
              "Mozilla\/5.0 zgrab\/0.x"
            ]
          },
          "host": "52.50.169.99",
          "tls_handshake": {
            "client_hello": {
              "random": "S\/2rkSFkzRB+vHwJ495hN4c\/o3zwwp0D+cIq+betto8="
            },
            "server_hello": {
              "version": {
                "name": "TLSv1.2",
                "value": 771
              },
              "random": "kB\/8T22IFZwZSBxjcIE2MQnzysqL1zhelJJSQAzQgpQ=",
              "session_id": "6\/AmfHQmeDHRfLNOuYgvA\/dvI+l5Z5G0wpBkcZCD3\/A=",
              "cipher_suite": {
                "hex": "0xC02F",
                "name": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
                "value": 49199
              },
              "compression_method": 0,
              "ocsp_stapling": false,
              "ticket": false,
              "secure_renegotiation": true,
              "heartbeat": true,
              "extended_master_secret": false
            },
            "server_certificates": {
              "certificate": {
                "raw": "MIIDMjCCAhoCCQD77HjQKOAAKDANBgkqhkiG9w0BAQsFADBbMQswCQYDVQQGEwJHQjETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMRQwEgYDVQQDDAtleGFtcGxlLmNvbTAeFw0xNjAxMjcxMTMyMTlaFw0yNzAxMDkxMTMyMTlaMFsxCzAJBgNVBAYTAkdCMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxFDASBgNVBAMMC2V4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAytLbg3uh+sKkR2boIzUMRTvvrSjq\/mCjEzkDt\/Amd7R+PNQdIgCEwZB92jlUGQmsFEBItto+YcXu5JHMx1fy86GaraV0CJQCnaZH\/FSjNI15orZqiFHvG7djP6oRH\/voqzajYPcF3e7iJcamRRheYe\/7YTrK2R9rEnms9YYUaWEkyPr\/GBjc6tfABy8\/Adw9LqUauxTe42eoECaBsWyhRIACwipaeG6L25bwB\/RRMgQ+uJ3aR\/AOUv1C6pEEWIkk53RhlGgzftsDNt3fMQlC8WLFxA1B1QJXOvycxZAwfNFpq7WcwlB77vJi\/oAOIrJRawvrF36DjGrPIuLLaEvO+QIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCY9BzvN9M\/s6GnnwdyQQk\/ZieMD7qzBIyV71Zmqr5D1qGCPiyGPmN6ViSg61G2iBUj\/bsLmG0B\/9IgfD\/Z5JjMVmmdRQNAbZ7I6HQHuG0KGeQUNISTfil7jdOD1Lf4NFZzcUQzeEWuouMNfNN03YYcnzU1k9In\/6a5cFMjJMIZuZrpYyzzmGD\/RMMIo11GHliS2bBls5MKCIiJn1h6O6vDfO8BdxNjRSctmZ\/vGo75wm0cSkpxuOW+VLEZ0A4pEYCNNcEKFxHLMTt6kFEreJsAMVqDRXaH0ZAZXh0Bvrolt91bduTpiEQmy3wOx5v54+tJd9q1yzi0DPqdThdiPSEU",
                "parsed": {
                  "version": 2,
                  "serial_number": "18153017033457926184",
                  "signature_algorithm": {
                    "name": "SHA256WithRSA",
                    "oid": "1.2.840.113549.1.1.11"
                  },
                  "issuer": {
                    "common_name": [
                      "example.com"
                    ],
                    "country": [
                      "GB"
                    ],
                    "organization": [
                      "Internet Widgits Pty Ltd"
                    ],
                    "province": [
                      "Some-State"
                    ]
                  },
                  "issuer_dn": "C=GB, ST=Some-State, O=Internet Widgits Pty Ltd, CN=example.com",
                  "validity": {
                    "start": "2016-01-27T11:32:19Z",
                    "end": "2027-01-09T11:32:19Z",
                    "length": 345600000
                  },
                  "subject": {
                    "common_name": [
                      "example.com"
                    ],
                    "country": [
                      "GB"
                    ],
                    "organization": [
                      "Internet Widgits Pty Ltd"
                    ],
                    "province": [
                      "Some-State"
                    ]
                  },
                  "subject_dn": "C=GB, ST=Some-State, O=Internet Widgits Pty Ltd, CN=example.com",
                  "subject_key_info": {
                    "key_algorithm": {
                      "name": "RSA",
                      "oid": ""
                    },
                    "rsa_public_key": {
                      "exponent": 65537,
                      "modulus": "ytLbg3uh+sKkR2boIzUMRTvvrSjq\/mCjEzkDt\/Amd7R+PNQdIgCEwZB92jlUGQmsFEBItto+YcXu5JHMx1fy86GaraV0CJQCnaZH\/FSjNI15orZqiFHvG7djP6oRH\/voqzajYPcF3e7iJcamRRheYe\/7YTrK2R9rEnms9YYUaWEkyPr\/GBjc6tfABy8\/Adw9LqUauxTe42eoECaBsWyhRIACwipaeG6L25bwB\/RRMgQ+uJ3aR\/AOUv1C6pEEWIkk53RhlGgzftsDNt3fMQlC8WLFxA1B1QJXOvycxZAwfNFpq7WcwlB77vJi\/oAOIrJRawvrF36DjGrPIuLLaEvO+Q==",
                      "length": 2048
                    },
                    "fingerprint_sha256": "a15d315ccac780335fe88c6dac861000a7c72c893fd22ccd711a75a79a556d23"
                  },
                  "extensions": {
                    "certificate_policies": [
                      
                    ]
                  },
                  "signature": {
                    "signature_algorithm": {
                      "name": "SHA256WithRSA",
                      "oid": "1.2.840.113549.1.1.11"
                    },
                    "value": "mPQc7zfTP7Ohp58HckEJP2YnjA+6swSMle9WZqq+Q9ahgj4shj5jelYkoOtRtogVI\/27C5htAf\/SIHw\/2eSYzFZpnUUDQG2eyOh0B7htChnkFDSEk34pe43Tg9S3+DRWc3FEM3hFrqLjDXzTdN2GHJ81NZPSJ\/+muXBTIyTCGbma6WMs85hg\/0TDCKNdRh5YktmwZbOTCgiIiZ9Yejurw3zvAXcTY0UnLZmf7xqO+cJtHEpKcbjlvlSxGdAOKRGAjTXBChcRyzE7epBRK3ibADFag0V2h9GQGV4dAb66JbfdW3bk6YhEJst8Dseb+ePrSXfatcs4tAz6nU4XYj0hFA==",
                    "valid": false,
                    "self_signed": true
                  },
                  "fingerprint_md5": "5770a8f2e15242797c009ae4fab2bee1",
                  "fingerprint_sha1": "8fa076d1bace6e9e8c51b28b00f3c7332c6bf129",
                  "fingerprint_sha256": "b74e42bb23d77c3c763c72fbfc4b9ea78562cff5e81e1e592b3ca2400f3917b7",
                  "tbs_noct_fingerprint": "239a375a39ac7bcad63570906930ea89d9581d510b222aefd31dd09ba38b8e83",
                  "spki_subject_fingerprint": "4eb2b18c0f3114ab90fd2864f47ffb431953b2195f7b1d08b92e7d0db311f4e3",
                  "tbs_fingerprint": "239a375a39ac7bcad63570906930ea89d9581d510b222aefd31dd09ba38b8e83",
                  "validation_level": "DV",
                  "names": [
                    "example.com"
                  ]
                }
              },
              "validation": {
                "browser_trusted": true
              }
            },
            "server_key_exchange": {
              "ecdh_params": {
                "curve_id": {
                  "name": "secp256r1",
                  "id": 23
                },
                "server_public": {
                  "x": {
                    "value": "Gomjw\/bOKTjCWOoDZpfW7HHfMN4v4vEcmkwyO\/sdKpU=",
                    "length": 256
                  },
                  "y": {
                    "value": "DsuqiaskqZIqQ\/k7cwhsdCeNn\/HNj6d8RHQXDN2Ur\/4=",
                    "length": 256
                  }
                }
              },
              "signature": {
                "raw": "RpElLd\/OrQct6jZpiHTueiZF+HutGckrgC0\/uM9hLng3uvc2tWwJrh8MK7cbejSfx6\/D2D6dyvzd0awez72ymsHvA5a3klx9wVhSW6gc22keuYI\/O2C689+j6Q848dFudcrW\/X7KX2OA5K87IJsySblkxDbcBKBh0SYlmANljCatojscAqGa7earCLQU6o2K\/cujUQvRv4TOLCKBoWNTu+DbRRD8yTm85dCzuCFYfnU7l+YtRosDAnxhSfvMNL1GrkFudKO+hZPWlLb3Kx08jwqU4\/ir4jBU6cW3qOY2lbqCovgTi2B+C0Bt69665XR8XOrL1Q5+1IEyX8Nbwm9TxA==",
                "type": "rsa",
                "valid": true,
                "signature_and_hash_type": {
                  "signature_algorithm": "rsa",
                  "hash_algorithm": "sha256"
                },
                "tls_version": {
                  "name": "TLSv1.2",
                  "value": 771
                }
              }
            },
            "client_key_exchange": {
              "ecdh_params": {
                "curve_id": {
                  "name": "secp256r1",
                  "id": 23
                },
                "client_public": {
                  "x": {
                    "value": "fPcb+777PkpDesUOpbt2xfZJzaFkb2xJzUsxD\/9geCA=",
                    "length": 256
                  },
                  "y": {
                    "value": "E\/jEWERWNXRosFC8YdCgcm4iz\/fR9N8H+d6OMU9Hbsk=",
                    "length": 256
                  }
                },
                "client_private": {
                  "value": "HzYuKgyDWH86ccMmU3FmY6kjqgxTfGX\/udR+aYnpdB8=",
                  "length": 32
                }
              }
            },
            "client_finished": {
              "verify_data": "prUdHna+7OXTVRln"
            },
            "server_finished": {
              "verify_data": "byzp6+KmbZ0N0EsB"
            },
            "key_material": {
              "master_secret": {
                "value": "PltqzCnEcsF1qWvlYxlvVYgjnmsya7+qmYJU\/sTcbLBhK91WkrJL0kYtei8IJeKN",
                "length": 48
              },
              "pre_master_secret": {
                "value": "s7TD6Y2q5POjTDdDl18pyzwXlAA2Bu2vQG1njhrCuh4=",
                "length": 32
              }
            }
          }
        }
      }
    }
  },
  "error": "Get https:\/\/52.50.169.99:443\/: unexpected EOF"
}
```