### PR TITLE
Set ClientRandom explicitly

### DIFF
--- a/ztools/ztls/common.go
+++ b/ztools/ztls/common.go
@@ -346,6 +346,9 @@ type Config struct {
 
 	// Enable use of the Extended Master Secret extension
 	ExtendedMasterSecret bool
+
+	// Explicitly set Client random
+	ClientRandom []byte
 }
 
 func (c *Config) serverInit() {

--- a/ztools/ztls/handshake_client.go
+++ b/ztools/ztls/handshake_client.go
@@ -90,10 +90,14 @@ func (c *Conn) clientHandshake() error {
 		}
 	}
 
-	_, err := io.ReadFull(c.config.rand(), hello.random)
-	if err != nil {
-		c.sendAlert(alertInternalError)
-		return errors.New("tls: short read from Rand: " + err.Error())
+	if len(c.config.ClientRandom) == 32 {
+		hello.random = c.config.ClientRandom
+	} else {
+		_, err := io.ReadFull(c.config.rand(), hello.random)
+		if err != nil {
+			c.sendAlert(alertInternalError)
+			return errors.New("tls: short read from Rand: " + err.Error())
+		}
 	}
 
 	if c.config.ExtendedRandom {

--- a/ztools/ztls/handshake_client.go
+++ b/ztools/ztls/handshake_client.go
@@ -91,7 +91,7 @@ func (c *Conn) clientHandshake() error {
 	}
 
 	if len(c.config.ClientRandom) == 32 {
-		hello.random = c.config.ClientRandom
+		copy(hello.random, c.config.ClientRandom)
 	} else {
 		_, err := io.ReadFull(c.config.rand(), hello.random)
 		if err != nil {


### PR DESCRIPTION
Added functionality: explicitly set ClientRandom.
Needed for Telex-style tag(which is now used by Tapdance along with its own tag to speed things up)