### PR TITLE
Added support to source the grabber traffic from a specific IP address / interface on the machine.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,14 @@
-ZGrab is an original work created at the University of Michigan, and is
-licensed under the Apache 2.0 license. However, ZGrab contains a fork of
-several packages from Golang standard library, as well as code from the
-BoringSSL test runner. Files that were created by Google, and new files in
-forks of packages maintained by Google have a Google copyright and fall under
-the ISC license.  All other files are copyright Regents of the University of
-Michigan, and fall under the Apache 2.0 license. Both licenses are reproduced
-at the bottom of this file.
+ZGrab is an original work created at the University of Michigan with contributions
+from Akamai Technologies Inc, and is licensed under the Apache 2.0 license.
+
+However, ZGrab contains a fork of several packages from Golang standard library,
+as well as code from the BoringSSL test runner. Files that were created by Google,
+and new files in forks of packages maintained by Google have a Google copyright
+and fall under the ISC license.
+
+All other files are copyright Regents of the University of Michigan with snippets
+copyright Akamai Technologies Inc. and fall under the Apache 2.0 license.
+Both licenses are reproduced at the bottom of this file.
 
 --------
 

--- a/main.go
+++ b/main.go
@@ -1,5 +1,7 @@
 /*
- * ZGrab Copyright 2015 Regents of the University of Michigan
+ * ZGrab
+ *   Copyright 2015 Regents of the University of Michigan
+ *   Copyright 2016 Akamai Technologies Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -20,6 +22,7 @@ import (
 	"flag"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"runtime"
 	"strings"
@@ -45,6 +48,7 @@ var (
 	timeout                       uint
 	tlsVersion                    string
 	rootCAFileName                string
+	sourceIP                      string
 )
 
 // Module configurations
@@ -68,6 +72,7 @@ func init() {
 	flag.BoolVar(&config.LookupDomain, "lookup-domain", false, "Input contains only domain names")
 	flag.StringVar(&interfaceName, "interface", "", "Network interface to send on")
 	flag.UintVar(&portFlag, "port", 80, "Port to grab on")
+	flag.StringVar(&sourceIP, "source", "", "Set the source IP address for traffic")
 	flag.UintVar(&timeout, "timeout", 10, "Set connection timeout in seconds")
 	flag.BoolVar(&config.TLS, "tls", false, "Grab over TLS")
 	flag.StringVar(&tlsVersion, "tls-version", "", "Max TLS version to use (implies --tls)")
@@ -138,6 +143,36 @@ func init() {
 	// Stop the lowliest idiot from using this to DoS people
 	if config.ConnectionsPerHost > 50 || config.ConnectionsPerHost < 1 {
 		zlog.Fatalf("--connections-per-host must be in the range [0,50]")
+	}
+
+	// If a source IP is specified, verify that the host is advertising the IP
+	// and has a chance to receive the responses.
+	if sourceIP != "" {
+		config.LocalAddressSet = false
+		providedAddr := net.ParseIP(sourceIP)
+		localInterfaces, localInterfacesErr := net.Interfaces()
+		if localInterfacesErr != nil {
+			zlog.Fatalf("Error getting Local interfaces: %s", localInterfacesErr.Error())
+		}
+		for idx, i := range localInterfaces {
+			addresses, adddressesErr := i.Addrs()
+			if adddressesErr != nil {
+				zlog.Fatalf("Error getting Local addresses for interface %d: %s", idx, adddressesErr.Error())
+			}
+			for _, address := range addresses {
+				castAddress := address.(*net.IPNet)
+				if castAddress.Contains(providedAddr) {
+					tcpAddr := &net.TCPAddr{
+						IP: address.(*net.IPNet).IP,
+					}
+					config.LocalAddress = tcpAddr
+					config.LocalAddressSet = true
+				}
+			}
+		}
+		if !config.LocalAddressSet {
+			zlog.Fatalf("Source IP (%s) was set but not found in the list of machine IPs", sourceIP)
+		}
 	}
 
 	// Validate SSH related flags

--- a/main.go
+++ b/main.go
@@ -150,6 +150,9 @@ func init() {
 	if sourceIP != "" {
 		config.LocalAddressSet = false
 		providedAddr := net.ParseIP(sourceIP)
+		if providedAddr == nil {
+			zlog.Fatalf("Error parsing provided IP: %s", sourceIP)
+		}
 		localInterfaces, localInterfacesErr := net.Interfaces()
 		if localInterfacesErr != nil {
 			zlog.Fatalf("Error getting Local interfaces: %s", localInterfacesErr.Error())
@@ -163,7 +166,7 @@ func init() {
 				castAddress := address.(*net.IPNet)
 				if castAddress.Contains(providedAddr) {
 					tcpAddr := &net.TCPAddr{
-						IP: address.(*net.IPNet).IP,
+						IP: castAddress.IP,
 					}
 					config.LocalAddress = tcpAddr
 					config.LocalAddressSet = true

--- a/zlib/config.go
+++ b/zlib/config.go
@@ -1,5 +1,7 @@
 /*
- * ZGrab Copyright 2015 Regents of the University of Michigan
+ * ZGrab
+ *   Copyright 2015 Regents of the University of Michigan
+ *   Copyright 2016 Akamai Technologies Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -18,6 +20,7 @@ import (
 	"encoding/csv"
 	"errors"
 	"io"
+	"net"
 	"strings"
 	"time"
 
@@ -98,6 +101,8 @@ type Config struct {
 	Timeout            time.Duration
 	Senders            uint
 	ConnectionsPerHost uint
+	LocalAddress       net.Addr
+	LocalAddressSet    bool
 
 	// DNS
 	LookupDomain bool

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -1,5 +1,7 @@
 /*
- * ZGrab Copyright 2015 Regents of the University of Michigan
+ * ZGrab
+ *   Copyright 2015 Regents of the University of Michigan
+ *   Copyright 2016 Akamai Technologies Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy
@@ -115,6 +117,9 @@ func makeDialer(c *Config) func(string) (*Conn, error) {
 		d := Dialer{
 			Deadline: deadline,
 		}
+		if c.LocalAddressSet {
+			d.LocalAddr = c.LocalAddress
+		}
 		conn, err := d.Dial(proto, addr)
 		conn.maxTlsVersion = c.TLSVersion
 		if err == nil {
@@ -131,6 +136,9 @@ func makeNetDialer(c *Config) func(string, string) (net.Conn, error) {
 		deadline := time.Now().Add(timeout)
 		d := Dialer{
 			Deadline: deadline,
+		}
+		if c.LocalAddressSet {
+			d.LocalAddr = c.LocalAddress
 		}
 		conn, err := d.Dial(proto, addr)
 		conn.maxTlsVersion = c.TLSVersion


### PR DESCRIPTION
The IP in question is checked to make sure that it is configured
for the device to reduce the ability to spoof.