### PR TITLE
Add Prometheus integration, update TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,9 @@
 language: go
 go:
-- 1.6.2
-before_install:
-- go get gopkg.in/check.v1
-- go get github.com/zmap/rc2
-- go get github.com/axw/gocov/gocov
-- go get github.com/mattn/goveralls
-- go get golang.org/x/tools/cmd/cover
-- go get github.com/mreiferson/go-httpclient
-- go get golang.org/x/net/context
-- go get github.com/op/go-logging
-- go get github.com/asaskevich/govalidator
-- go get github.com/zmap/zlint
-before_script:
-- mkdir -p $GOPATH/src/github.com/zmap
-- ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/zmap/ || true
+- 1.7.4
+install:
+- go get ./...
+- go get -t ./...
 script:
   - go test -v ./...
 notifications:

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func init() {
 	flag.StringVar(&inputFileName, "input-file", "-", "Input filename, use - for stdin")
 	flag.StringVar(&metadataFileName, "metadata-file", "-", "File to record banner-grab metadata, use - for stdout")
 	flag.StringVar(&logFileName, "log-file", "-", "File to log to, use - for stderr")
-	flag.StringVar(&prometheusAddress, "prometheus", "", "Address to use for prometheus server, value less than zero disables")
+	flag.StringVar(&prometheusAddress, "prometheus", "", "Address to use for Prometheus server (e.g. localhost:8080). If empty, Prometheus is disabled.")
 	flag.BoolVar(&config.LookupDomain, "lookup-domain", false, "Input contains only domain names")
 	flag.StringVar(&interfaceName, "interface", "", "Network interface to send on")
 	flag.UintVar(&portFlag, "port", 80, "Port to grab on")


### PR DESCRIPTION
This adds Prometheus integration via the --prometheus flag. The flags
defaults to empty. When the flag is non-empty it launches an HTTP server
at the specified endpoint (e.g. "localhost:8080"), that exposes the
Prometheus metric source API at the /metrics path.

This also updates TravisCI to download dependencies more sanely, and
bumps the version of Golang used by TravisCI to 1.7.4.