### PR TITLE
Add GEX-SHA1 DH KEX to xssh scanner.

### DIFF
--- a/ztools/xssh/common.go
+++ b/ztools/xssh/common.go
@@ -33,6 +33,8 @@ var supportedCiphers = []string{
 
 // supportedKexAlgos specifies the supported key-exchange algorithms in
 // preference order.
+// These are *not* the supported DH KEX algorithms, they are the x/crypto defaults.
+// All supported algorithms are given in the kex.go -> kexAlgoMap variable.
 var supportedKexAlgos = []string{
 	kexAlgoCurve25519SHA256,
 	// P384 and P521 are not constant-time yet, but since we don't

--- a/ztools/xssh/common.go
+++ b/ztools/xssh/common.go
@@ -39,7 +39,7 @@ var supportedKexAlgos = []string{
 	kexAlgoCurve25519SHA256,
 	// P384 and P521 are not constant-time yet, but since we don't
 	// reuse ephemeral keys, using them for ECDH should be OK.
-	kexAlgoDHGEXSHA1, kexAlgoECDH256, kexAlgoECDH384, kexAlgoECDH521,
+	kexAlgoECDH256, kexAlgoECDH384, kexAlgoECDH521,
 	kexAlgoDH14SHA1, kexAlgoDH1SHA1,
 }
 

--- a/ztools/xssh/common.go
+++ b/ztools/xssh/common.go
@@ -37,7 +37,7 @@ var supportedKexAlgos = []string{
 	kexAlgoCurve25519SHA256,
 	// P384 and P521 are not constant-time yet, but since we don't
 	// reuse ephemeral keys, using them for ECDH should be OK.
-	kexAlgoECDH256, kexAlgoECDH384, kexAlgoECDH521,
+	kexAlgoDHGEXSHA1, kexAlgoECDH256, kexAlgoECDH384, kexAlgoECDH521,
 	kexAlgoDH14SHA1, kexAlgoDH1SHA1,
 }
 

--- a/ztools/xssh/flag.go
+++ b/ztools/xssh/flag.go
@@ -69,8 +69,8 @@ func (kaList *KexAlgorithmsList) Set(value string) error {
 	kaList.IsSet = true
 	for _, alg := range strings.Split(value, ",") {
 		isValid := false
-		for _, val := range supportedKexAlgos {
-			if val == alg {
+		for knownAlgoName, _ := range kexAlgoMap {
+			if knownAlgoName == alg {
 				isValid = true
 				break
 			}

--- a/ztools/xssh/flag.go
+++ b/ztools/xssh/flag.go
@@ -14,6 +14,9 @@ type XSSHConfig struct {
 	HostKeyAlgorithms HostKeyAlgorithmsList
 	KexAlgorithms     KexAlgorithmsList
 	Verbose           bool
+	GEXMinBits        int
+	GEXMaxBits        int
+	GEXPreferredBits  int
 }
 
 type HostKeyAlgorithmsList struct {
@@ -105,4 +108,8 @@ func init() {
 	)
 	flag.Var(&pkgConfig.KexAlgorithms, "xssh-kex-algorithms", kexAlgUsage)
 	flag.BoolVar(&pkgConfig.Verbose, "xssh-verbose", false, "Output additional information.")
+
+	flag.IntVar(&pkgConfig.GEXMinBits, "xssh-gex-min-bits", 1024, "The minimum number of bits to accept for a GEX DH key exchange.")
+	flag.IntVar(&pkgConfig.GEXMaxBits, "xssh-gex-max-bits", 8192, "The maximum number of bits to accept for a GEX DH key exchange.")
+	flag.IntVar(&pkgConfig.GEXPreferredBits, "xssh-gex-preferred-bits", 2048, "The preferred number of bits to accept for a GEX DH key exchange.")
 }

--- a/ztools/xssh/kex.go
+++ b/ztools/xssh/kex.go
@@ -29,6 +29,7 @@ const (
 	kexAlgoECDH384          = "ecdh-sha2-nistp384"
 	kexAlgoECDH521          = "ecdh-sha2-nistp521"
 	kexAlgoCurve25519SHA256 = "curve25519-sha256@libssh.org"
+	kexAlgoDHGEXSHA1        = "diffie-hellman-group-exchange-sha1"
 )
 
 // kexResult captures the outcome of a key exchange.
@@ -583,6 +584,7 @@ func init() {
 	kexAlgoMap[kexAlgoECDH384] = &ecdh{curve: elliptic.P384()}
 	kexAlgoMap[kexAlgoECDH256] = &ecdh{curve: elliptic.P256()}
 	kexAlgoMap[kexAlgoCurve25519SHA256] = &curve25519sha256{}
+	kexAlgoMap[kexAlgoDHGEXSHA1] = &dhGEXSHA1{}
 }
 
 // curve25519sha256 implements the curve25519-sha256@libssh.org key

--- a/ztools/xssh/kex_enhancement.go
+++ b/ztools/xssh/kex_enhancement.go
@@ -1,0 +1,224 @@
+package ssh
+
+import (
+	"crypto"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math/big"
+)
+
+type dhGEXSHA1 struct {
+	g, p *big.Int
+}
+
+const (
+	MinBits       = 1024
+	MaxBits       = 8192
+	PreferredBits = 2048
+)
+
+func (gex *dhGEXSHA1) diffieHellman(theirPublic, myPrivate *big.Int) (*big.Int, error) {
+	if theirPublic.Sign() <= 0 || theirPublic.Cmp(gex.p) >= 0 {
+		return nil, fmt.Errorf("ssh: DH parameter out of bounds")
+	}
+	return new(big.Int).Exp(theirPublic, myPrivate, gex.p), nil
+}
+
+func (gex *dhGEXSHA1) Client(c packetConn, randSource io.Reader, magics *handshakeMagics) (*kexResult, error) {
+	hashFunc := crypto.SHA1
+
+	// Send GexRequest
+	kexDHGexRequest := kexDHGexRequestMsg{
+		MinBits:      MinBits,
+		PreferedBits: PreferredBits,
+		MaxBits:      MaxBits,
+	}
+	if err := c.writePacket(Marshal(&kexDHGexRequest)); err != nil {
+		return nil, err
+	}
+
+	// *Receive GexGroup*
+	packet, err := c.readPacket()
+	if err != nil {
+		return nil, err
+	}
+
+	var kexDHGexGroup kexDHGexGroupMsg
+	if err = Unmarshal(packet, &kexDHGexGroup); err != nil {
+		return nil, err
+	}
+
+	// reject if p's bit length < MinBits or > MaxBits
+	if kexDHGexGroup.P.BitLen() < MinBits || kexDHGexGroup.P.BitLen() > MaxBits {
+		return nil, fmt.Errorf("Server-generated gex p (dont't ask) is out of range (%d bits)", kexDHGexGroup.P.BitLen())
+	}
+
+	gex.p = kexDHGexGroup.P
+	gex.g = kexDHGexGroup.G
+
+	// *Send GexInit
+	x, err := rand.Int(randSource, gex.p)
+	if err != nil {
+		return nil, err
+	}
+	X := new(big.Int).Exp(gex.g, x, gex.p)
+	kexDHGexInit := kexDHGexInitMsg{
+		X: X,
+	}
+	if err := c.writePacket(Marshal(&kexDHGexInit)); err != nil {
+		return nil, err
+	}
+
+	// Receive GexReply
+	packet, err = c.readPacket()
+	if err != nil {
+		return nil, err
+	}
+
+	var kexDHGexReply kexDHGexReplyMsg
+	if err = Unmarshal(packet, &kexDHGexReply); err != nil {
+		return nil, err
+	}
+
+	kInt, err := gex.diffieHellman(kexDHGexReply.Y, x)
+	if err != nil {
+		return nil, err
+	}
+
+	h := hashFunc.New()
+	magics.write(h)
+	writeString(h, kexDHGexReply.HostKey)
+	binary.Write(h, binary.BigEndian, uint32(MinBits))
+	binary.Write(h, binary.BigEndian, uint32(PreferredBits))
+	binary.Write(h, binary.BigEndian, uint32(MaxBits))
+	writeInt(h, gex.p)
+	writeInt(h, gex.g)
+	writeInt(h, X)
+	writeInt(h, kexDHGexReply.Y)
+	K := make([]byte, intLength(kInt))
+	marshalInt(K, kInt)
+	h.Write(K)
+
+	return &kexResult{
+		H:         h.Sum(nil),
+		K:         K,
+		HostKey:   kexDHGexReply.HostKey,
+		Signature: kexDHGexReply.Signature,
+		Hash:      crypto.SHA1,
+	}, nil
+}
+
+func (gex *dhGEXSHA1) Server(c packetConn, randSource io.Reader, magics *handshakeMagics, priv Signer) (result *kexResult, err error) {
+	hashFunc := crypto.SHA1
+
+	// *Receive GexRequest*
+	packet, err := c.readPacket()
+	if err != nil {
+		return
+	}
+	var kexDHGexRequest kexDHGexRequestMsg
+	if err = Unmarshal(packet, &kexDHGexRequest); err != nil {
+		return
+	}
+
+	// smoosh the user's preferred size into our own limits
+	if kexDHGexRequest.PreferedBits > MaxBits {
+		kexDHGexRequest.PreferedBits = MaxBits
+	}
+	if kexDHGexRequest.PreferedBits < MinBits {
+		kexDHGexRequest.PreferedBits = MinBits
+	}
+	// fix min/max if they're inconsistent.  technically, we could just pout
+	// and hang up, but there's no harm in giving them the benefit of the
+	// doubt and just picking a bitsize for them.
+	if kexDHGexRequest.MinBits > kexDHGexRequest.PreferedBits {
+		kexDHGexRequest.MinBits = kexDHGexRequest.PreferedBits
+	}
+	if kexDHGexRequest.MaxBits < kexDHGexRequest.PreferedBits {
+		kexDHGexRequest.MaxBits = kexDHGexRequest.PreferedBits
+	}
+
+	// *Send GexGroup*
+	// generate prime
+	// TODO: Not implemented yet, should load primes from /etc/ssh/moduli
+	gex.p, _ = new(big.Int).SetString("D1391174233D315398FE2830AC6B2B66BCCD01B0A634899F339B7879F1DB85712E9DC4E4B1C6C8355570C1D2DCB53493DF18175A9C53D1128B592B4C72D97136F5542FEB981CBFE8012FDD30361F288A42BD5EBB08BAB0A5640E1AC48763B2ABD1945FEE36B2D55E1D50A1C86CED9DD141C4E7BE2D32D9B562A0F8E2E927020E91F58B57EB9ACDDA106A59302D7E92AD5F6E851A45FA1CFE86029A0F727F65A8F475F33572E2FDAB6073F0C21B8B54C3823DB2EF068927E5D747498F96361507", 16)
+	gex.g = big.NewInt(5)
+	kexDHGexGroup := kexDHGexGroupMsg{
+		P: gex.p,
+		G: gex.g,
+	}
+	if err := c.writePacket(Marshal(&kexDHGexGroup)); err != nil {
+		return nil, err
+	}
+
+	// *Receive GexInit
+	packet, err = c.readPacket()
+	if err != nil {
+		return
+	}
+	var kexDHGexInit kexDHGexInitMsg
+	if err = Unmarshal(packet, &kexDHGexInit); err != nil {
+		return
+	}
+
+	// var maxP = big.NewInt(0)
+	// *maxP = *gex.p
+	// y, err := rand.Int(randSource, maxP.Add(maxP, big.NewInt(-1)).Div(maxP, big.NewInt(2)))
+	// fmt.Println("Server:", maxP.BitLen(), gex.p.BitLen())
+	//y, err := rand.Int(randSource, gex.p)
+	y, err := rand.Int(randSource, gex.p)
+	if err != nil {
+		return
+	}
+
+	Y := new(big.Int).Exp(gex.g, y, gex.p)
+	kInt, err := gex.diffieHellman(kexDHGexInit.X, y)
+	if err != nil {
+		return nil, err
+	}
+
+	hostKeyBytes := priv.PublicKey().Marshal()
+
+	h := hashFunc.New()
+	magics.write(h)
+	writeString(h, hostKeyBytes)
+	binary.Write(h, binary.BigEndian, uint32(MinBits))
+	binary.Write(h, binary.BigEndian, uint32(PreferredBits))
+	binary.Write(h, binary.BigEndian, uint32(MaxBits))
+	writeInt(h, gex.p)
+	writeInt(h, gex.g)
+	writeInt(h, kexDHGexInit.X)
+	writeInt(h, Y)
+
+	K := make([]byte, intLength(kInt))
+	marshalInt(K, kInt)
+	h.Write(K)
+
+	H := h.Sum(nil)
+
+	// H is already a hash, but the hostkey signing will apply its
+	// own key-specific hash algorithm.
+	sig, err := signAndMarshal(priv, randSource, H)
+	if err != nil {
+		return nil, err
+	}
+
+	kexDHGexReply := kexDHGexReplyMsg{
+		HostKey:   hostKeyBytes,
+		Y:         Y,
+		Signature: sig,
+	}
+	packet = Marshal(&kexDHGexReply)
+
+	err = c.writePacket(packet)
+
+	return &kexResult{
+		H:         H,
+		K:         K,
+		HostKey:   hostKeyBytes,
+		Signature: sig,
+		Hash:      crypto.SHA1,
+	}, nil
+}

--- a/ztools/xssh/messages.go
+++ b/ztools/xssh/messages.go
@@ -137,6 +137,35 @@ type kexDHReplyMsg struct {
 	Signature []byte
 }
 
+const msgKexDHGexGroup = 31
+
+type kexDHGexGroupMsg struct {
+	P *big.Int `sshtype:"31"`
+	G *big.Int
+}
+
+const msgKexDHGexInit = 32
+
+type kexDHGexInitMsg struct {
+	X *big.Int `sshtype:"32"`
+}
+
+const msgKexDHGexReply = 33
+
+type kexDHGexReplyMsg struct {
+	HostKey   []byte `sshtype:"33"`
+	Y         *big.Int
+	Signature []byte
+}
+
+const msgKexDHGexRequest = 34
+
+type kexDHGexRequestMsg struct {
+	MinBits      uint32 `sshtype:"34"`
+	PreferedBits uint32
+	MaxBits      uint32
+}
+
 // See RFC 4253, section 10.
 const msgServiceRequest = 5
 


### PR DESCRIPTION
Add the ```diffie-hellman-group-exchange-sha1``` DH KEX to the xssh scanner. This is based on the implementation by @breml with additions for customization and JSON output.

Example output -- 

```json
      "algorithm_selection": {
        "dh_kex_algorithm": "diffie-hellman-group-exchange-sha1",
        "host_key_algorithm": "ssh-rsa",
        "client_to_server_alg_group": {
          "cipher": "aes128-ctr",
          "mac": "hmac-sha1",
          "compression": "none"
        },
        "server_to_client_alg_group": {
          "cipher": "aes128-ctr",
          "mac": "hmac-sha1",
          "compression": "none"
        }
      },
      "dh_key_exchange": {
        "parameters": {
          "prime": {
            "value": "///////////JD9qiIWjCNMTGYouA3BzRKQJOCIpnzHQCC76mOxObIlFKCHmONATd75UZs806QxswKwpt8l8UN0/hNW1tUcJF5IW1dmJefsb0TELppjftawv/XLb0Brft7jhr+1qJn6WunyQRfEsf5kkoZlHs5Fs9wgB8uKFjvwWY2kg2HFXTmmkWP6j9JM9fg2VdI9yjrZYcYvNWIIVSu57VKQdwlpZtZww1Tkq8mATxdGwIyhghfDKQXkYuNs474553LBgOhgObJ4Oi7Aeij7XFXfBvTFLJ3ivL9pVYFxg5lUl86pVq5RXSJhiY+gUQFXKOWoqsqmj//////////w==",
            "length": 2048
          },
          "generator": {
            "value": "Ag==",
            "length": 8
          },
          "server_public": {
            "value": "JYOBCiR4VtqQqkWnLW+PTVrQLacaTFGFKvzLuSpRHSeApn0dlinAmMZM4vOs1dKATjCN4/ULkxohbEj9OQZq8Gq8rxNnzdmiVNFNVkjI8DhrSF0JHKTsFjCVa1J4h3jB5NwFAGxsa+Hqy/L/4K6JlL8izlNUZQU7QU2UpnY25dDra75VNSEJ1mhXcr1bczSb3z+4V8TQwLsq0XtY9DA4GkjbTnJ8SRN/YnXSskRaeGsaENEON+YNoDEw3/9l7t00XMV505CtSBjsbm1WcRqQV2CFsy8ndH0KI4UxvCDP8y6spndm42exRYTKeTTUnxv7X0W1oksS6yoY4zC5YOnCqA==",
            "length": 2048
          }
        },
        "server_host_key": {
          "rsa_public_key": {
            "exponent": 65537,
            "modulus": "28tCPT/38f7AyAlrO2p3CRB16lNb8n+SVwG8TMnVAy4Q1/jQSa8tTp81CwxIXIN4f5lGXlujgnzAb7vhygpnBShvZXVFzfAu2tJFwytLy9tvEEYvRCcnRB1FWLW+pcqaOpuPxOjYx2BRmpAxRdO1b4ciuenHiiAZcDgMm7dp2wpMGAh4eP+ApSkql5ytkiZI0iwy3Co4nKupfg6fa/jBKtRxMMeWfjSO3w6I7uctpOWTkQEhwyRYZgzg+ltFGvZ/0dkPw4tBsUBpBIhUHBBl2k005eaKn5T/9ji3YsO0IOwDlae85hYviggPZJ02MFLkpAdWkWx+VL5YzMztZhorZw==",
            "length": 2048
          },
          "raw": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDby0I9P/fx/sDICWs7ancJEHXqU1vyf5JXAbxMydUDLhDX+NBJry1OnzULDEhcg3h/mUZeW6OCfMBvu+HKCmcFKG9ldUXN8C7a0kXDK0vL228QRi9EJydEHUVYtb6lypo6m4/E6NjHYFGakDFF07VvhyK56ceKIBlwOAybt2nbCkwYCHh4/4ClKSqXnK2SJkjSLDLcKjicq6l+Dp9r+MEq1HEwx5Z+NI7fDoju5y2k5ZORASHDJFhmDOD6W0Ua9n/R2Q/Di0GxQGkEiFQcEGXaTTTl5oqflP/2OLdiw7Qg7AOVp7zmFi+KCA9knTYwUuSkB1aRbH5UvljMzO1mGitn",
          "algorithm": "ssh-rsa",
          "fingerprint_sha256": "043ff81fe7b1f9284c5b2a6ec31cfb26171288c2c52fc4ce0850d04be8ce35ba"
        },
        "server_signature": "AAAAB3NzaC1yc2EAAAEAYV08/cV+73VGrKuALZ/EzBXTyAQk0u71NygWDXVnXfMY/OG+f0NaHPhya88/aGBSDIxG3+/qH542foJRFsGvzihQq/fKwrauxv0UQFxR70yZKrJQOGxufioF4WaZUoXzFuZ5AsxkgNsUJGeHCL04/zZCviKiovZ8Mepqwry1x+zDEsV7ZblFVCGUGSekJEcC1/DdqXLIF1kERUcr4M6hEXuYOdBwuE3AzOQxnd5x/whRPhvdS4MnVEU3eH+b2DLyinsDCFapfeAS3K/VCRsJlA0oTlWKmpGJCACMnMRsT1UdrBBKWl21tlCLziINY15+gXwRb2703XOPkKaMXzBf0w=="
      },
```

The sub-grouped parameters and broken out signature fields will be added via their appropriate issues' commit.

@breml's original implementation: https://github.com/breml/crypto/commit/09c4372f769753a4e040ee9903e67e1fee11a1ba