### PR TITLE
Fix SNI insertion

### DIFF
--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -214,7 +214,7 @@ func makeHTTPGrabber(config *Config, grabData *GrabData) func(string, string, st
 
 		var tlsConfig *ztls.Config
 		if config.TLS {
-			tlsConfig = makeTLSConfig(config, urlHost)
+			tlsConfig = makeTLSConfig(config, httpHost)
 		}
 
 		transport := &http.Transport{


### PR DESCRIPTION
With inputs of the form `<IP>,<domain_name>`, and no `lookup-domain` option, the SNI extension in the ClientHellos sent by `zgrab` contained `<IP>:<port>` instead of the domain name. This is non-standard and probably unwanted behavior.