### PR TITLE
Fix renegotiation extension unmarshall

### DIFF
--- a/ztools/ztls/handshake_messages.go
+++ b/ztools/ztls/handshake_messages.go
@@ -460,7 +460,7 @@ func (m *clientHelloMsg) unmarshal(data []byte) bool {
 				m.signatureAndHashes[i].signature = d[1]
 				d = d[2:]
 			}
-		case extensionRenegotiationInfo + 1:
+		case extensionRenegotiationInfo:
 			if length != 1 || data[0] != 0 {
 				return false
 			}


### PR DESCRIPTION
When `unmarshal`-ling ClientHellos, the `renegotiation_info` extension failed to be identified.