### PR TITLE
Add external ClientHello support

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func init() {
 	flag.BoolVar(&config.S7, "s7", false, "Send some Siemens S7 data")
 	flag.BoolVar(&config.NoSNI, "no-sni", false, "Do not send domain name in TLS handshake regardless of whether known")
 
-	flag.StringVar(&clientHelloFileName, "raw-client-hello", "", "Provide a raw ClientHello to be sent; only the SNI will be rewritten (implies --tls)")
+	flag.StringVar(&clientHelloFileName, "raw-client-hello", "", "Provide a raw ClientHello to be sent; only the SNI will be rewritten")
 
 	flag.BoolVar(&config.ExportsOnly, "export-ciphers", false, "Send only export ciphers")
 	flag.BoolVar(&config.ExportsDHOnly, "export-dhe-ciphers", false, "Send only export DHE ciphers")
@@ -347,7 +347,6 @@ func init() {
 			zlog.Fatal(err)
 		} else {
 			config.ExternalClientHello = clientHello
-			config.ForceClientHello = true
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ var (
 	tlsVersion                    string
 	rootCAFileName                string
 	prometheusAddress             string
+	clientHelloFileName           string
 )
 
 // Module configurations
@@ -97,6 +98,8 @@ func init() {
 	flag.BoolVar(&config.Fox, "fox", false, "Send some Niagara Fox Tunneling data")
 	flag.BoolVar(&config.S7, "s7", false, "Send some Siemens S7 data")
 	flag.BoolVar(&config.NoSNI, "no-sni", false, "Do not send domain name in TLS handshake regardless of whether known")
+
+	flag.StringVar(&clientHelloFileName, "raw-client-hello", "", "Provide a raw ClientHello to be sent; only the SNI will be rewritten (implies --tls)")
 
 	flag.BoolVar(&config.ExportsOnly, "export-ciphers", false, "Send only export ciphers")
 	flag.BoolVar(&config.ExportsDHOnly, "export-dhe-ciphers", false, "Send only export DHE ciphers")
@@ -337,6 +340,16 @@ func init() {
 	}
 	logger := zlog.New(logFile, "banner-grab")
 	config.ErrorLog = logger
+
+	// Open TLS ClientHello, if applicable
+	if clientHelloFileName != "" {
+		if clientHello, err := ioutil.ReadFile(clientHelloFileName); err != nil {
+			zlog.Fatal(err)
+		} else {
+			config.ExternalClientHello = clientHello
+			config.ForceClientHello = true
+		}
+	}
 }
 
 func main() {

--- a/zlib/config.go
+++ b/zlib/config.go
@@ -127,6 +127,8 @@ type Config struct {
 	ExtendedMasterSecret          bool
 	TLSVerbose                    bool
 	SignedCertificateTimestampExt bool
+	ForceClientHello              bool
+	ExternalClientHello           []byte
 
 	// SSH
 	SSH SSHScanConfig

--- a/zlib/config.go
+++ b/zlib/config.go
@@ -127,7 +127,6 @@ type Config struct {
 	ExtendedMasterSecret          bool
 	TLSVerbose                    bool
 	SignedCertificateTimestampExt bool
-	ForceClientHello              bool
 	ExternalClientHello           []byte
 
 	// SSH

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -67,7 +67,6 @@ type Conn struct {
 	CipherSuites                  []uint16
 	ForceSuites                   bool
 	noSNI                         bool
-	ForceClientHello              bool
 	ExternalClientHello           []byte
 	extendedRandom                bool
 	gatherSessionTicket           bool
@@ -316,8 +315,7 @@ func (c *Conn) TLSHandshake() error {
 	if c.offerExtendedMasterSecret {
 		tlsConfig.ExtendedMasterSecret = true
 	}
-	if c.ForceClientHello {
-		tlsConfig.ForceClientHello = true
+	if c.ExternalClientHello != nil {
 		tlsConfig.ExternalClientHello = c.ExternalClientHello
 	}
 

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -67,6 +67,8 @@ type Conn struct {
 	CipherSuites                  []uint16
 	ForceSuites                   bool
 	noSNI                         bool
+	ForceClientHello              bool
+	ExternalClientHello           []byte
 	extendedRandom                bool
 	gatherSessionTicket           bool
 	offerExtendedMasterSecret     bool
@@ -87,6 +89,10 @@ func (c *Conn) getUnderlyingConn() net.Conn {
 		return c.tlsConn
 	}
 	return c.conn
+}
+
+func (c *Conn) SetExternalClientHello(clientHello []byte) {
+	c.ExternalClientHello = clientHello
 }
 
 func (c *Conn) SetExtendedRandom() {
@@ -309,6 +315,10 @@ func (c *Conn) TLSHandshake() error {
 	}
 	if c.offerExtendedMasterSecret {
 		tlsConfig.ExtendedMasterSecret = true
+	}
+	if c.ForceClientHello {
+		tlsConfig.ForceClientHello = true
+		tlsConfig.ExternalClientHello = c.ExternalClientHello
 	}
 
 	c.tlsConn = ztls.Client(c.conn, tlsConfig)

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -195,6 +195,10 @@ func makeTLSConfig(config *Config, urlHost string) *ztls.Config {
 	if !config.NoSNI && urlHost != "" {
 		tlsConfig.ServerName = urlHost
 	}
+	if config.ForceClientHello {
+		tlsConfig.ForceClientHello = true
+		tlsConfig.ExternalClientHello = config.ExternalClientHello
+	}
 
 	return tlsConfig
 }
@@ -375,6 +379,10 @@ func makeGrabber(config *Config) func(*Conn) error {
 		}
 		if config.ExtendedMasterSecret {
 			c.SetOfferExtendedMasterSecret()
+		}
+		if config.ForceClientHello {
+			c.SetExternalClientHello(config.ExternalClientHello)
+			c.ForceClientHello = true
 		}
 		if config.TLSVerbose {
 			c.SetTLSVerbose()

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -195,8 +195,7 @@ func makeTLSConfig(config *Config, urlHost string) *ztls.Config {
 	if !config.NoSNI && urlHost != "" {
 		tlsConfig.ServerName = urlHost
 	}
-	if config.ForceClientHello {
-		tlsConfig.ForceClientHello = true
+	if config.ExternalClientHello != nil {
 		tlsConfig.ExternalClientHello = config.ExternalClientHello
 	}
 
@@ -380,9 +379,8 @@ func makeGrabber(config *Config) func(*Conn) error {
 		if config.ExtendedMasterSecret {
 			c.SetOfferExtendedMasterSecret()
 		}
-		if config.ForceClientHello {
+		if config.ExternalClientHello != nil {
 			c.SetExternalClientHello(config.ExternalClientHello)
-			c.ForceClientHello = true
 		}
 		if config.TLSVerbose {
 			c.SetTLSVerbose()

--- a/ztools/ztls/common.go
+++ b/ztools/ztls/common.go
@@ -354,8 +354,7 @@ type Config struct {
 	// Explicitly set Client random
 	ClientRandom []byte
 
-	// Explicitly set ClientHello
-	ForceClientHello bool
+	// Explicitly set ClientHello with raw data
 	ExternalClientHello []byte
 }
 

--- a/ztools/ztls/common.go
+++ b/ztools/ztls/common.go
@@ -353,6 +353,10 @@ type Config struct {
 
 	// Explicitly set Client random
 	ClientRandom []byte
+
+	// Explicitly set ClientHello
+	ForceClientHello bool
+	ExternalClientHello []byte
 }
 
 func (c *Config) serverInit() {

--- a/ztools/ztls/handshake_client.go
+++ b/ztools/ztls/handshake_client.go
@@ -37,129 +37,155 @@ func (c *Conn) clientHandshake() error {
 		c.config = defaultConfig()
 	}
 
-	if len(c.config.ServerName) == 0 && !c.config.InsecureSkipVerify {
-		return errors.New("tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config")
+	var hello *clientHelloMsg
+
+	var session *ClientSessionState
+	var sessionCache ClientSessionCache
+	var cacheKey string
+
+	// first, let's check if a ClientHello template was provided by the user
+	if c.config.ForceClientHello {
+
+		hello = new(clientHelloMsg)
+
+		if !hello.unmarshal(c.config.ExternalClientHello) {
+			return errors.New("could not read the ClientHello provided")
+		}
+
+		// update the SNI with one name, whether or not the extension was already there
+		hello.serverName = c.config.ServerName
+
+		// then we update the 'raw' value of the message
+		hello.raw = nil
+		_ = hello.marshal()
+
+		session = nil
+		sessionCache = nil
+
+	} else {
+
+		if len(c.config.ServerName) == 0 && !c.config.InsecureSkipVerify {
+			return errors.New("tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config")
+		}
+
+		hello = &clientHelloMsg{
+			vers:                 c.config.maxVersion(),
+			compressionMethods:   []uint8{compressionNone},
+			random:               make([]byte, 32),
+			ocspStapling:         true,
+			serverName:           c.config.ServerName,
+			supportedCurves:      c.config.curvePreferences(),
+			supportedPoints:      []uint8{pointFormatUncompressed},
+			nextProtoNeg:         len(c.config.NextProtos) > 0,
+			secureRenegotiation:  true,
+			alpnProtocols:        c.config.NextProtos,
+			extendedMasterSecret: c.config.maxVersion() >= VersionTLS10 && c.config.ExtendedMasterSecret,
+		}
+
+		if c.config.ForceSessionTicketExt {
+			hello.ticketSupported = true
+		}
+		if c.config.SignedCertificateTimestampExt {
+			hello.sctEnabled = true
+		}
+
+		if c.config.HeartbeatEnabled && !c.config.ExtendedRandom {
+			hello.heartbeatEnabled = true
+			hello.heartbeatMode = heartbeatModePeerAllowed
+		}
+
+		possibleCipherSuites := c.config.cipherSuites()
+		hello.cipherSuites = make([]uint16, 0, len(possibleCipherSuites))
+
+		if c.config.ForceSuites {
+			hello.cipherSuites = possibleCipherSuites
+		} else {
+
+		NextCipherSuite:
+			for _, suiteId := range possibleCipherSuites {
+				for _, suite := range implementedCipherSuites {
+					if suite.id != suiteId {
+						continue
+					}
+					// Don't advertise TLS 1.2-only cipher suites unless
+					// we're attempting TLS 1.2.
+					if hello.vers < VersionTLS12 && suite.flags&suiteTLS12 != 0 {
+						continue
+					}
+					hello.cipherSuites = append(hello.cipherSuites, suiteId)
+					continue NextCipherSuite
+				}
+			}
+		}
+
+		if len(c.config.ClientRandom) == 32 {
+			copy(hello.random, c.config.ClientRandom)
+		} else {
+			_, err := io.ReadFull(c.config.rand(), hello.random)
+			if err != nil {
+				c.sendAlert(alertInternalError)
+				return errors.New("tls: short read from Rand: " + err.Error())
+			}
+		}
+
+		if c.config.ExtendedRandom {
+			hello.extendedRandomEnabled = true
+			hello.extendedRandom = make([]byte, 32)
+			if _, err := io.ReadFull(c.config.rand(), hello.extendedRandom); err != nil {
+				return errors.New("tls: short read from Rand: " + err.Error())
+			}
+		}
+
+		if hello.vers >= VersionTLS12 {
+			hello.signatureAndHashes = c.config.signatureAndHashesForClient()
+		}
+
+		sessionCache = c.config.ClientSessionCache
+		if c.config.SessionTicketsDisabled {
+			sessionCache = nil
+		}
+
+		if sessionCache != nil {
+			hello.ticketSupported = true
+
+			// Try to resume a previously negotiated TLS session, if
+			// available.
+			cacheKey = clientSessionCacheKey(c.conn.RemoteAddr(), c.config)
+			candidateSession, ok := sessionCache.Get(cacheKey)
+			if ok {
+				// Check that the ciphersuite/version used for the
+				// previous session are still valid.
+				cipherSuiteOk := false
+				for _, id := range hello.cipherSuites {
+					if id == candidateSession.cipherSuite {
+						cipherSuiteOk = true
+						break
+					}
+				}
+
+				versOk := candidateSession.vers >= c.config.minVersion() &&
+					candidateSession.vers <= c.config.maxVersion()
+				if versOk && cipherSuiteOk {
+					session = candidateSession
+				}
+			}
+		}
+
+		if session != nil {
+			hello.sessionTicket = session.sessionTicket
+			// A random session ID is used to detect when the
+			// server accepted the ticket and is resuming a session
+			// (see RFC 5077).
+			hello.sessionId = make([]byte, 16)
+			if _, err := io.ReadFull(c.config.rand(), hello.sessionId); err != nil {
+				c.sendAlert(alertInternalError)
+				return errors.New("tls: short read from Rand: " + err.Error())
+			}
+		}
 	}
 
 	c.handshakeLog = new(ServerHandshake)
 	c.heartbleedLog = new(Heartbleed)
-
-	hello := &clientHelloMsg{
-		vers:                 c.config.maxVersion(),
-		compressionMethods:   []uint8{compressionNone},
-		random:               make([]byte, 32),
-		ocspStapling:         true,
-		serverName:           c.config.ServerName,
-		supportedCurves:      c.config.curvePreferences(),
-		supportedPoints:      []uint8{pointFormatUncompressed},
-		nextProtoNeg:         len(c.config.NextProtos) > 0,
-		secureRenegotiation:  true,
-		alpnProtocols:        c.config.NextProtos,
-		extendedMasterSecret: c.config.maxVersion() >= VersionTLS10 && c.config.ExtendedMasterSecret,
-	}
-
-	if c.config.ForceSessionTicketExt {
-		hello.ticketSupported = true
-	}
-	if c.config.SignedCertificateTimestampExt {
-		hello.sctEnabled = true
-	}
-
-	if c.config.HeartbeatEnabled && !c.config.ExtendedRandom {
-		hello.heartbeatEnabled = true
-		hello.heartbeatMode = heartbeatModePeerAllowed
-	}
-
-	possibleCipherSuites := c.config.cipherSuites()
-	hello.cipherSuites = make([]uint16, 0, len(possibleCipherSuites))
-
-	if c.config.ForceSuites {
-		hello.cipherSuites = possibleCipherSuites
-	} else {
-
-	NextCipherSuite:
-		for _, suiteId := range possibleCipherSuites {
-			for _, suite := range implementedCipherSuites {
-				if suite.id != suiteId {
-					continue
-				}
-				// Don't advertise TLS 1.2-only cipher suites unless
-				// we're attempting TLS 1.2.
-				if hello.vers < VersionTLS12 && suite.flags&suiteTLS12 != 0 {
-					continue
-				}
-				hello.cipherSuites = append(hello.cipherSuites, suiteId)
-				continue NextCipherSuite
-			}
-		}
-	}
-
-	if len(c.config.ClientRandom) == 32 {
-		copy(hello.random, c.config.ClientRandom)
-	} else {
-		_, err := io.ReadFull(c.config.rand(), hello.random)
-		if err != nil {
-			c.sendAlert(alertInternalError)
-			return errors.New("tls: short read from Rand: " + err.Error())
-		}
-	}
-
-	if c.config.ExtendedRandom {
-		hello.extendedRandomEnabled = true
-		hello.extendedRandom = make([]byte, 32)
-		if _, err := io.ReadFull(c.config.rand(), hello.extendedRandom); err != nil {
-			return errors.New("tls: short read from Rand: " + err.Error())
-		}
-	}
-
-	if hello.vers >= VersionTLS12 {
-		hello.signatureAndHashes = c.config.signatureAndHashesForClient()
-	}
-
-	var session *ClientSessionState
-	var cacheKey string
-	sessionCache := c.config.ClientSessionCache
-	if c.config.SessionTicketsDisabled {
-		sessionCache = nil
-	}
-
-	if sessionCache != nil {
-		hello.ticketSupported = true
-
-		// Try to resume a previously negotiated TLS session, if
-		// available.
-		cacheKey = clientSessionCacheKey(c.conn.RemoteAddr(), c.config)
-		candidateSession, ok := sessionCache.Get(cacheKey)
-		if ok {
-			// Check that the ciphersuite/version used for the
-			// previous session are still valid.
-			cipherSuiteOk := false
-			for _, id := range hello.cipherSuites {
-				if id == candidateSession.cipherSuite {
-					cipherSuiteOk = true
-					break
-				}
-			}
-
-			versOk := candidateSession.vers >= c.config.minVersion() &&
-				candidateSession.vers <= c.config.maxVersion()
-			if versOk && cipherSuiteOk {
-				session = candidateSession
-			}
-		}
-	}
-
-	if session != nil {
-		hello.sessionTicket = session.sessionTicket
-		// A random session ID is used to detect when the
-		// server accepted the ticket and is resuming a session
-		// (see RFC 5077).
-		hello.sessionId = make([]byte, 16)
-		if _, err := io.ReadFull(c.config.rand(), hello.sessionId); err != nil {
-			c.sendAlert(alertInternalError)
-			return errors.New("tls: short read from Rand: " + err.Error())
-		}
-	}
 
 	c.writeRecord(recordTypeHandshake, hello.marshal())
 	c.handshakeLog.ClientHello = hello.MakeLog()

--- a/ztools/ztls/handshake_client.go
+++ b/ztools/ztls/handshake_client.go
@@ -44,7 +44,7 @@ func (c *Conn) clientHandshake() error {
 	var cacheKey string
 
 	// first, let's check if a ClientHello template was provided by the user
-	if c.config.ForceClientHello {
+	if c.config.ExternalClientHello != nil {
 
 		hello = new(clientHelloMsg)
 


### PR DESCRIPTION
This commit enables importing raw ClientHellos to be sent during the `zgrab` scans.

When providing such information with the `raw-client-hello` option, `zgrab` will only rewrite the SNI extension with the current domain name to be queried. The ClientHello contents will stay otherwise untouched (well, except for the extensions order). As a side effect, other options like `chrome-ciphers` or `tls-session-ticket` are ignored.

Main motivations behind this:
- some extensions may not be known to `zgrab`, but we might want to send them nonetheless;
- `zgrab` options do not cover every field/value to be written in the ClientHello probe. I've been using `scapy` for designing TLS messages, which is more exhaustive and flexible IMHO. (The [PR](https://github.com/secdev/scapy/pull/476) has been in review for a few months now.)

With the fix from PR #221, you may test this commit with something like the command below. Wireshark should show that the outgoing ClientHello contains an ALPN extension (unsupported by `zgrab` for now).
`echo "8.8.8.8,www.google.com" | zgrab --tls --port 443 --raw-client-hello dummy_clientHello.txt`


[dummy_clientHello.txt](https://github.com/zmap/zgrab/files/748575/dummy_clientHello.txt)
