### PR TITLE
* Removed --encoding option to fix 185

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,7 +36,6 @@ import (
 
 // Command-line flags
 var (
-	encoding                      string
 	outputFileName, inputFileName string
 	logFileName, metadataFileName string
 	messageFileName               string
@@ -63,7 +62,6 @@ var (
 // Pre-main bind flags to variables
 func init() {
 
-	flag.StringVar(&config.Encoding, "encoding", "string", "Encode banner as string|hex|base64")
 	flag.StringVar(&outputFileName, "output-file", "-", "Output filename, use - for stdout")
 	flag.StringVar(&inputFileName, "input-file", "-", "Input filename, use - for stdin")
 	flag.StringVar(&metadataFileName, "metadata-file", "-", "File to record banner-grab metadata, use - for stdout")
@@ -249,17 +247,6 @@ func init() {
 	if config.Heartbleed && !(config.StartTLS || config.TLS) {
 		zlog.Fatal("Must specify one of --tls or --starttls for --heartbleed")
 	}
-
-	encoding = strings.ToLower(config.Encoding)
-	// Check output encoding
-	switch encoding {
-	case "string":
-	case "base64":
-	case "hex":
-	default:
-		zlog.Fatalf("Invalid encoding '%s'", config.Encoding)
-	}
-	config.Encoding = encoding
 
 	// Validate port
 	if portFlag > 65535 {

--- a/zlib/config.go
+++ b/zlib/config.go
@@ -106,9 +106,6 @@ type Config struct {
 	// DNS
 	LookupDomain bool
 
-	// Encoding
-	Encoding string
-
 	// TLS
 	TLS                           bool
 	TLSVersion                    uint16

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -429,7 +429,7 @@ func (c *Conn) SMTPBanner(b []byte) (int, error) {
 }
 
 func (c *Conn) EHLO(domain string) error {
-    cmd := []byte("EHLO " + domain + "\r\n")
+	cmd := []byte("EHLO " + domain + "\r\n")
 	if _, err := c.getUnderlyingConn().Write(cmd); err != nil {
 		return err
 	}

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -75,9 +75,6 @@ type Conn struct {
 
 	domain string
 
-	// Encoding type
-	ReadEncoding string
-
 	// SSH
 	sshScan *SSHScanConfig
 
@@ -432,7 +429,7 @@ func (c *Conn) SMTPBanner(b []byte) (int, error) {
 }
 
 func (c *Conn) EHLO(domain string) error {
-	cmd := []byte("EHLO " + domain + "\r\n")
+    cmd := []byte("EHLO " + domain + "\r\n")
 	if _, err := c.getUnderlyingConn().Write(cmd); err != nil {
 		return err
 	}

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -383,7 +383,6 @@ func makeGrabber(config *Config) func(*Conn) error {
 		if config.SSH.SSH {
 			c.sshScan = &config.SSH
 		}
-		c.ReadEncoding = config.Encoding
 		if config.TLS {
 			if err := c.TLSHandshake(); err != nil {
 				c.erroredComponent = "tls"


### PR DESCRIPTION
This commit removes the encoding flag and associated structures as it wasn't implemented/didn't have a function. Addresses Issue #185 