### PR TITLE
Add command-line flags to metadata output.

### DIFF
--- a/main.go
+++ b/main.go
@@ -369,6 +369,7 @@ func main() {
 		TLSVersion: tlsVersion,
 		MailType:   mailType,
 		SNISupport: !config.NoSNI,
+		Flags:      os.Args,
 	}
 	enc := json.NewEncoder(metadataFile)
 	if err := enc.Encode(&s); err != nil {

--- a/summary.go
+++ b/summary.go
@@ -33,6 +33,7 @@ type Summary struct {
 	MailType   string
 	CAFile     string
 	SNISupport bool
+	Flags      []string
 }
 
 type encodedSummary struct {
@@ -49,6 +50,7 @@ type encodedSummary struct {
 	MailType   *string       `json:"mail_type"`
 	CAFile     *string       `json:"ca_file_name"`
 	SNISupport bool          `json:"sni_support"`
+	Flags      []string      `json:"flags"`
 }
 
 func (s *Summary) MarshalJSON() ([]byte, error) {
@@ -63,6 +65,7 @@ func (s *Summary) MarshalJSON() ([]byte, error) {
 	e.Senders = s.Senders
 	e.Timeout = uint(s.Timeout / time.Second)
 	e.SNISupport = s.SNISupport
+	e.Flags = s.Flags
 	if s.TLSVersion != "" {
 		e.TLSVersion = &s.TLSVersion
 	}


### PR DESCRIPTION
Add the cmd flags to the metadata output IOT help document scan configuration.

Output format --

```json
{
  "port": 22,
  "success_count": 1,
  "failure_count": 0,
  "total": 1,
  "start_time": "2017-02-04T17:02:46-05:00",
  "end_time": "2017-02-04T17:02:46-05:00",
  "duration": 0,
  "senders": 1000,
  "timeout": 10,
  "tls_version": null,
  "mail_type": null,
  "ca_file_name": null,
  "sni_support": true,
  "flags": [
    "./zgrab",
    "--xssh",
    "--port",
    "22",
    "--output-file",
    "output.json",
    "--metadata-file",
    "metadata.json"
  ]
}
```