### PR TITLE
Made SMTP, IMAP, and POP3 RFC Compliant

### DIFF
--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -454,6 +454,12 @@ func (c *Conn) SMTPHelp() error {
 	return err
 }
 
+func (c *Conn) SMTPQuit() error {
+	cmd := []byte("QUIT\r\n")
+	_, err := c.getUnderlyingConn().Write(cmd)
+	return err
+}
+
 func (c *Conn) readPop3Response(res []byte) (int, error) {
 	return util.ReadUntilRegex(c.getUnderlyingConn(), res, pop3EndRegex)
 }
@@ -464,6 +470,12 @@ func (c *Conn) POP3Banner(b []byte) (int, error) {
 	return n, err
 }
 
+func (c *Conn) POP3Quit() error {
+	cmd := []byte("QUIT\r\n")
+	_, err := c.getUnderlyingConn().Write(cmd)
+	return err
+}
+
 func (c *Conn) readImapStatusResponse(res []byte) (int, error) {
 	return util.ReadUntilRegex(c.getUnderlyingConn(), res, imapStatusEndRegex)
 }
@@ -472,6 +484,12 @@ func (c *Conn) IMAPBanner(b []byte) (int, error) {
 	n, err := c.readImapStatusResponse(b)
 	c.grabData.Banner = string(b[0:n])
 	return n, err
+}
+
+func (c *Conn) IMAPQuit() error {
+	cmd := []byte("a001 CLOSE\r\n")
+	_, err := c.getUnderlyingConn().Write(cmd)
+	return err
 }
 
 func (c *Conn) CheckHeartbleed(b []byte) (int, error) {

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -514,21 +514,20 @@ func makeGrabber(config *Config) func(*Conn) error {
 			}
 		}
 
-		if config.Banners {
-			if config.SMTP {
-				if err := c.SMTPQuit(); err != nil {
-					return err
-				}
-			} else if config.POP3 {
-				if err := c.POP3Quit(); err != nil {
-					return err
-				}
-			} else if config.IMAP {
-				if err := c.IMAPQuit(); err != nil {
-					return err
-				}
+		if config.SMTP {
+			if err := c.SMTPQuit(); err != nil {
+				return err
+			}
+		} else if config.POP3 {
+			if err := c.POP3Quit(); err != nil {
+				return err
+			}
+		} else if config.IMAP {
+			if err := c.IMAPQuit(); err != nil {
+				return err
 			}
 		}
+
 		if config.Modbus {
 			if _, err := c.SendModbusEcho(); err != nil {
 				c.erroredComponent = "modbus"

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -516,14 +516,17 @@ func makeGrabber(config *Config) func(*Conn) error {
 
 		if config.SMTP {
 			if err := c.SMTPQuit(); err != nil {
+				c.erroredComponent = "quit"
 				return err
 			}
 		} else if config.POP3 {
 			if err := c.POP3Quit(); err != nil {
+				c.erroredComponent = "quit"
 				return err
 			}
 		} else if config.IMAP {
 			if err := c.IMAPQuit(); err != nil {
+				c.erroredComponent = "quit"
 				return err
 			}
 		}

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -514,6 +514,21 @@ func makeGrabber(config *Config) func(*Conn) error {
 			}
 		}
 
+		if config.Banners {
+			if config.SMTP {
+				if err := c.SMTPQuit(); err != nil {
+					return err
+				}
+			} else if config.POP3 {
+				if err := c.POP3Quit(); err != nil {
+					return err
+				}
+			} else if config.IMAP {
+				if err := c.IMAPQuit(); err != nil {
+					return err
+				}
+			}
+		}
 		if config.Modbus {
 			if _, err := c.SendModbusEcho(); err != nil {
 				c.erroredComponent = "modbus"


### PR DESCRIPTION
Resolves #238 

SMTP server requires Quit command as stated in RFC 5321 Section 3.1

IMAP and POP3 are both ambiguous on whether a server requires a close/quit command because a timeout could be implemented by the server. Either way, sending a quit command probably doesn't hurt. 