### PR TITLE
Adding CPSuri field

### DIFF
--- a/ztools/x509/x509.go
+++ b/ztools/x509/x509.go
@@ -601,6 +601,7 @@ type Certificate struct {
 
 	// Certificate Policies values
 	QualifierId          [][]asn1.ObjectIdentifier
+	CPSuri               [][]string
 	ExplicitTexts        [][]asn1.RawValue
 	NoticeRefOrgnization [][]asn1.RawValue
 	NoticeRefNumbers     [][]NoticeNumber


### PR DESCRIPTION
This is one of the two options for policy qualifier types in certificate policy extension, per RFC5280 4.2.1.4. The other option UserNotice is already in place.