### PR TITLE
certpolicy output

### DIFF
--- a/zcertificate/main.go
+++ b/zcertificate/main.go
@@ -67,8 +67,7 @@ func main() {
 }
 
 func runZlint(x509Cert *x509.Certificate) (map[string]string, error) {
-	m := make(map[string]int)
-	zlintReport, err := zlint.ParsedTestHandler(x509Cert, m)
+	zlintReport, err := zlint.ParsedTestHandler(x509Cert)
 	if err != nil {
 		return nil, err
 	}
@@ -77,13 +76,12 @@ func runZlint(x509Cert *x509.Certificate) (map[string]string, error) {
 
 func appendZlintToCertificate(x509Cert *x509.Certificate, lintResult map[string]string) ([]byte, error) {
 	return json.Marshal(struct {
-		Raw []byte			`json:"raw"`
-		CertData *x509.Certificate	`json:"parsed"`
-		Zlint map[string]string 	`json:"zlint"`
-
+		Raw      []byte            `json:"raw"`
+		CertData *x509.Certificate `json:"parsed"`
+		Zlint    map[string]string `json:"zlint"`
 	}{
-		Raw: 		x509Cert.Raw,
-		CertData: 	x509Cert,
-		Zlint:          lintResult,
+		Raw:      x509Cert.Raw,
+		CertData: x509Cert,
+		Zlint:    lintResult,
 	})
 }

--- a/ztools/x509/extensions.go
+++ b/ztools/x509/extensions.go
@@ -66,10 +66,20 @@ type BasicConstraints struct {
 	MaxPathLen *int `json:"max_path_len,omitempty"`
 }
 
+type NoticeReference struct {
+	Organization		string			`json:"organization,omitempty"`
+	NoticeNumbers		NoticeNumber		`json:"notice_numbers,omitempty"`
+}
+
+type UserNoticeData struct {
+	ExplicitText		string			`json:"explicit_text,omitempty"`
+	NoticeReference		[]NoticeReference	`json:"notice_reference,omitempty"`
+}
+
 type CertificatePoliciesJSON struct {
-	PolicyIdentifier	string		`json:"policy_identifier,omitempty"`
-	CPSUri			[]string	`json:"cps,omitempty"`
-	UserNotice		[]string	`json:"user_notice,omitempty"`
+	PolicyIdentifier	string			`json:"id,omitempty"`
+	CPSUri			[]string		`json:"cps,omitempty"`
+	UserNotice		[]UserNoticeData	`json:"user_notice,omitempty"`
 }
 
 type CertificatePolicies []CertificatePoliciesJSON
@@ -91,9 +101,19 @@ func (cp *CertificatePoliciesData) MarshalJSON() ([]byte, error) {
 		for _, uri := range cp.CPSUri[idx] {
 			cpsJSON.CPSUri = append(cpsJSON.CPSUri, uri)
 		}
+
 		for _, explicit_text := range cp.ExplicitTexts[idx] {
-			cpsJSON.UserNotice = append(cpsJSON.UserNotice, explicit_text)
+			uNoticeData := UserNoticeData{}
+			uNoticeData.ExplicitText = explicit_text
+			for _, organization := range cp.NoticeRefOrganization[idx] {
+				noticeRef := NoticeReference{}
+				noticeRef.Organization = organization
+				noticeRef.NoticeNumbers = cp.NoticeRefNumbers[idx][0]
+				uNoticeData.NoticeReference = append(uNoticeData.NoticeReference, noticeRef)
+			}
+			cpsJSON.UserNotice = append(cpsJSON.UserNotice, uNoticeData)
 		}
+
 		policies = append(policies, cpsJSON)
 	}
 	return json.Marshal(policies)

--- a/ztools/x509/extensions.go
+++ b/ztools/x509/extensions.go
@@ -97,11 +97,6 @@ func (cp *CertificatePolicies) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	//qualifierIds := make([][]string, len(cp))
-	//for idx, oid := range cp.QualifierId {
-	//	qualifierIds[idx] = oid.String()
-	//}
-
 	parsed := jsonCertificatePolicies{
 		PolicyIdentifiers:     policyIdentifiers,
 		QualifierId:           qualifierIds,

--- a/ztools/x509/extensions.go
+++ b/ztools/x509/extensions.go
@@ -102,15 +102,14 @@ func (cp *CertificatePoliciesData) MarshalJSON() ([]byte, error) {
 			cpsJSON.CPSUri = append(cpsJSON.CPSUri, uri)
 		}
 
-		for _, explicit_text := range cp.ExplicitTexts[idx] {
+		for idx2, explicit_text := range cp.ExplicitTexts[idx] {
 			uNoticeData := UserNoticeData{}
 			uNoticeData.ExplicitText = explicit_text
-			for _, organization := range cp.NoticeRefOrganization[idx] {
-				noticeRef := NoticeReference{}
-				noticeRef.Organization = organization
-				noticeRef.NoticeNumbers = cp.NoticeRefNumbers[idx][0]
-				uNoticeData.NoticeReference = append(uNoticeData.NoticeReference, noticeRef)
-			}
+			noticeRef := NoticeReference{}
+			organization := cp.NoticeRefOrganization[idx][idx2]
+			noticeRef.Organization = organization
+			noticeRef.NoticeNumbers = cp.NoticeRefNumbers[idx][idx2]
+			uNoticeData.NoticeReference = append(uNoticeData.NoticeReference, noticeRef)
 			cpsJSON.UserNotice = append(cpsJSON.UserNotice, uNoticeData)
 		}
 

--- a/ztools/x509/extensions.go
+++ b/ztools/x509/extensions.go
@@ -346,8 +346,6 @@ func (kid SubjAuthKeyId) MarshalJSON() ([]byte, error) {
 
 type ExtendedKeyUsage []ExtKeyUsage
 
-//type CertificatePolicies []asn1.ObjectIdentifier
-
 // The string functions for CertValidationLevel are auto-generated via
 // `go generate <full_path_to_x509_package>` or running `go generate` in the package directory
 //go:generate stringer -type=CertValidationLevel -output=generated_certvalidationlevel_string.go
@@ -539,14 +537,6 @@ var OrganizationValidationOIDs = map[string]interface{}{
 	// TurkTrust
 	"2.16.792.3.0.3.1.1.2": nil,
 }
-
-//func (cp CertificatePolicies) MarshalJSON() ([]byte, error) {
-//	out := make([]string, len(cp))
-//	for idx, oid := range cp {
-//		out[idx] = oid.String()
-//	}
-//	return json.Marshal(out)
-//}
 
 // TODO pull out other types
 type AuthorityInfoAccess struct {

--- a/ztools/x509/x509.go
+++ b/ztools/x509/x509.go
@@ -1455,6 +1455,7 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 					for _, qualifier := range policy.Qualifiers {
 						out.QualifierId[i] = append(out.QualifierId[i], qualifier.PolicyQualifierId)
 						userNoticeOID := asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 2}
+						cpsURIOID := asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 1}
 						if qualifier.PolicyQualifierId.Equal(userNoticeOID) {
 							var un userNotice
 							if _, err = asn1.Unmarshal(qualifier.Qualifier.FullBytes, &un); err != nil {
@@ -1469,6 +1470,13 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 								out.NoticeRefNumbers[i] = append(out.NoticeRefNumbers[i], un.NoticeRef.NoticeNumbers)
 								out.ParsedNoticeRefOrganization[i] = append(out.ParsedNoticeRefOrganization[i], string(un.NoticeRef.Organization.Bytes))
 							}
+						}
+						if qualifier.PolicyQualifierId.Equal(cpsURIOID) {
+							var cpsURIRaw asn1.RawValue
+							if _, err = asn1.Unmarshal(qualifier.Qualifier.FullBytes, &cpsURIRaw); err != nil {
+								return nil, err
+							}
+							out.CPSuri[i] = append(out.CPSuri[i], string(cpsURIRaw.Bytes))
 						}
 					}
 				}

--- a/ztools/x509/x509.go
+++ b/ztools/x509/x509.go
@@ -601,9 +601,13 @@ type Certificate struct {
 
 	// Certificate Policies values
 	QualifierId          [][]asn1.ObjectIdentifier
+	CPSuri               [][]string
 	ExplicitTexts        [][]asn1.RawValue
 	NoticeRefOrgnization [][]asn1.RawValue
 	NoticeRefNumbers     [][]NoticeNumber
+
+	ParsedExplicitTexts         [][]string
+	ParsedNoticeRefOrganization [][]string
 
 	// Name constraints
 	NameConstraintsCritical     bool // if true then the name constraints are marked critical.
@@ -1441,6 +1445,10 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 				out.ExplicitTexts = make([][]asn1.RawValue, len(policies))
 				out.NoticeRefOrgnization = make([][]asn1.RawValue, len(policies))
 				out.NoticeRefNumbers = make([][]NoticeNumber, len(policies))
+				out.ParsedExplicitTexts = make([][]string, len(policies))
+				out.ParsedNoticeRefOrganization = make([][]string, len(policies))
+				out.CPSuri = make([][]string, len(policies))
+
 				for i, policy := range policies {
 					out.PolicyIdentifiers[i] = policy.Policy
 					// parse optional Qualifier for zlint
@@ -1454,10 +1462,12 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 							}
 							if len(un.ExplicitText.Bytes) != 0 {
 								out.ExplicitTexts[i] = append(out.ExplicitTexts[i], un.ExplicitText)
+								out.ParsedExplicitTexts[i] = append(out.ParsedExplicitTexts[i], string(un.ExplicitText.Bytes))
 							}
 							if un.NoticeRef.Organization.Bytes != nil || un.NoticeRef.NoticeNumbers != nil {
 								out.NoticeRefOrgnization[i] = append(out.NoticeRefOrgnization[i], un.NoticeRef.Organization)
 								out.NoticeRefNumbers[i] = append(out.NoticeRefNumbers[i], un.NoticeRef.NoticeNumbers)
+								out.ParsedNoticeRefOrganization[i] = append(out.ParsedNoticeRefOrganization[i], string(un.NoticeRef.Organization.Bytes))
 							}
 						}
 					}


### PR DESCRIPTION
Output of ./zcertificate:

{"raw":"MIIE+jCCA+KgAwIBAgIQZyIjammE5+m7FKjyKv530TANBgkqhkiG9w0BAQsFADBCMQswCQYDVQQGEwJVUzEWMBQGA1UEChMNR2VvVHJ1c3QgSW5jLjEbMBkGA1UEAxMSUmFwaWRTU0wgU0hBMjU2IENBMB4XDTE2MDEyMjAwMDAwMFoXDTE3MDEyMjIzNTk1OVowgZcxCzAJBgNVBAYTAlVTMR0wGwYDVQQIDBREaXN0cmljdCBvZiBDb2x1bWJpYTETMBEGA1UEBwwKV2FzaGluZ3RvbjESMBAGA1UECgwJZmFubmllbWFlMRwwGgYDVQQLDBNpbnRlcm5ldGVuZ2luZWVyaW5nMSIwIAYDVQQDDBlzZWNvcHMtaWRldi5mYW5uaWVtYWUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2cc+jwLSRF2MI679cOzCQGoLC1X2DmA53NK0WSaUISDCTuQLTeocloKI4797bYX4RiEwh5kpinARk2SwbqjDzpHv86jELPVaMGBbgEfXtoqGcmXFEOaTw6WaroLhZEDVQW82qEXu/LeaicPyrGYeGRk1fAMDQRT+FjIdUraKGti+pkfuLVqCDYQ3WcYJyc57NE/uIOlS3MgCSxZ2kZm4CbtyMQzdDDTPi+uBMrWCL3/n8Pq/jnwjoCPxMB23jj911l8+OtPhULkd6DO0ohY5p/ABH0YNzb2hKVig5qgrBJKUZoYwpa92S6F480AFd29lgOs8ATTYrQ7xFjkW7g1WcQIDAQABo4IBlDCCAZAwJAYDVR0RBB0wG4IZc2Vjb3BzLWlkZXYuZmFubmllbWFlLmNvbTAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwbwYDVR0gBGgwZjBkBgZngQwBAgIwWjAqBggrBgEFBQcCARYeaHR0cHM6Ly93d3cucmFwaWRzc2wuY29tL2xlZ2FsMCwGCCsGAQUFBwICMCAaHmh0dHBzOi8vd3d3LnJhcGlkc3NsLmNvbS9sZWdhbDAfBgNVHSMEGDAWgBSXwidQnsLJ7AyIMsh8reKmAU/abzArBgNVHR8EJDAiMCCgHqAchhpodHRwOi8vZ3Auc3ltY2IuY29tL2dwLmNybDBXBggrBgEFBQcBAQRLMEkwHwYIKwYBBQUHMAGGE2h0dHA6Ly9ncC5zeW1jZC5jb20wJgYIKwYBBQUHMAKGGmh0dHA6Ly9ncC5zeW1jYi5jb20vZ3AuY3J0MBMGCisGAQQB1nkCBAMBAf8EAgUAMA0GCSqGSIb3DQEBCwUAA4IBAQB5QfrZ5MKGtu21GIljw/y5a1UyUW1ZYN0Myp/MZTuf4Cg4Fh2UFUZwHoEHy7tCkHofhGHSAnqu2yGHYU2A3ETQiZZwZB/OJZZL34/1jzPE9xVbmJ3nKIkJ7YNaBcPI/prSTsQIl8p7ySBllwO1T4n830MiYIFrBj3mAiIjmAIBC81n2W6WXG73VK+0CKNv0t0SU1Lt28A5LBVtanKXFEHyLVeB1w38dAwxAe+YQg9MrfXqt8l7SwZlUm79H4I1A1rVc3zzrfN7CkVmHmOJxyVozKa01Z4JT0ruFiBNkbZYsBck26BOPPSpjh/8KoNfpNRMF3KdvEJNb8eFCvmqwqAZ","parsed":{"version":3,"serial_number":"137087739974214472786606647825739446225","signature_algorithm":{"name":"SHA256WithRSA","oid":"1.2.840.113549.1.1.11"},"issuer":{"common_name":["RapidSSL SHA256 CA"],"country":["US"],"organization":["GeoTrust Inc."]},"issuer_dn":"C=US, O=GeoTrust Inc., CN=RapidSSL SHA256 CA","validity":{"start":"2016-01-22T00:00:00Z","end":"2017-01-22T23:59:59Z","length":31708799},"subject":{"common_name":["secops-idev.fanniemae.com"],"country":["US"],"locality":["Washington"],"organization":["fanniemae"],"organizational_unit":["internetengineering"],"province":["District of Columbia"]},"subject_dn":"C=US, ST=District of Columbia, L=Washington, O=fanniemae, OU=internetengineering, CN=secops-idev.fanniemae.com","subject_key_info":{"key_algorithm":{"name":"RSA"},"rsa_public_key":{"exponent":65537,"modulus":"2cc+jwLSRF2MI679cOzCQGoLC1X2DmA53NK0WSaUISDCTuQLTeocloKI4797bYX4RiEwh5kpinARk2SwbqjDzpHv86jELPVaMGBbgEfXtoqGcmXFEOaTw6WaroLhZEDVQW82qEXu/LeaicPyrGYeGRk1fAMDQRT+FjIdUraKGti+pkfuLVqCDYQ3WcYJyc57NE/uIOlS3MgCSxZ2kZm4CbtyMQzdDDTPi+uBMrWCL3/n8Pq/jnwjoCPxMB23jj911l8+OtPhULkd6DO0ohY5p/ABH0YNzb2hKVig5qgrBJKUZoYwpa92S6F480AFd29lgOs8ATTYrQ7xFjkW7g1WcQ==","length":2048},"fingerprint_sha256":"48315885c728a91f0c2bf73985b2662c150a3cb9ba65e6c57965ead0f0cc523c"},"extensions":{"key_usage":{"digital_signature":true,"key_encipherment":true,"value":5},"basic_constraints":{"is_ca":false},"subject_alt_name":{"dns_names":["secops-idev.fanniemae.com"]},"crl_distribution_points":["http://gp.symcb.com/gp.crl"],"authority_key_id":"97c227509ec2c9ec0c8832c87cade2a6014fda6f","extended_key_usage":[1,2],"certificate_policies":[{"policy_information":[{"policy_identifier":"2.23.140.1.2.2","policy_qualifiers":[{"policy_qualifier_info":[{"qualifier_id":"1.3.6.1.5.5.7.2.1","cps_uri":"https://www.rapidssl.com/legal"},{"qualifier_id":"1.3.6.1.5.5.7.2.2","user_notice":[{"explicit_text":"https://www.rapidssl.com/legal"}]}]}]}]}],"authority_info_access":{"ocsp_urls":["http://gp.symcd.com"],"issuer_urls":["http://gp.symcb.com/gp.crt"]},"ct_poison":true},"signature":{"signature_algorithm":{"name":"SHA256WithRSA","oid":"1.2.840.113549.1.1.11"},"value":"eUH62eTChrbttRiJY8P8uWtVMlFtWWDdDMqfzGU7n+AoOBYdlBVGcB6BB8u7QpB6H4Rh0gJ6rtshh2FNgNxE0ImWcGQfziWWS9+P9Y8zxPcVW5id5yiJCe2DWgXDyP6a0k7ECJfKe8kgZZcDtU+J/N9DImCBawY95gIiI5gCAQvNZ9lullxu91SvtAijb9LdElNS7dvAOSwVbWpylxRB8i1XgdcN/HQMMQHvmEIPTK316rfJe0sGZVJu/R+CNQNa1XN8863zewpFZh5jicclaMymtNWeCU9K7hYgTZG2WLAXJNugTjz0qY4f/CqDX6TUTBdynbxCTW/HhQr5qsKgGQ==","valid":false,"self_signed":false},"fingerprint_md5":"b68074a0e57313c1e73aa4e83307fd70","fingerprint_sha1":"78d9ca2b664d599e62f3697fede8a37879d0d65f","fingerprint_sha256":"9f687b25ed812f253cb78026a97c0eb4fb5d18170dcb54bb7a372bf600555896","tbs_noct_fingerprint":"0da978120e9fa5e3386942d01893ae1064b16820a9e5fb5f13b9154dd550907c","spki_subject_fingerprint":"a087e0125113dec8992aea9545a6258f76b58d8cfedb76396ea86676ff5c53ea","tbs_fingerprint":"098a221d8dcc26ba0859a27620eb486e0c15a4293e5a17b1c995726291915be0","validation_level":"OV","names":["secops-idev.fanniemae.com"],"redacted":false},"zlint":{"basic_constraints_not_critical":"NA","ca_country_name_invalid":"NA","ca_country_name_missing":"NA","ca_crl_sign_not_set":"NA","ca_dig_sign_not_set":"NA","ca_key_cert_sign_not_set":"NA","ca_key_usage_missing":"NA","ca_key_usage_not_critical":"NA","ca_organization_name_missing":"NA","ca_subject_field_empty":"NA","cert_contains_unique_identifier":"pass","cert_extensions_version_not_3":"pass","cert_policy_conflicts_with_locality":"NA","cert_policy_conflicts_with_org":"NA","cert_policy_conflicts_with_postal":"NA","cert_policy_conflicts_with_province":"NA","cert_policy_conflicts_with_street":"NA","cert_policy_iv_requires_country":"NA","cert_policy_iv_requires_province_or_locality":"NA","cert_policy_ov_requires_country":"pass","cert_policy_ov_requires_province_or_locality":"pass","cert_policy_requires_org":"pass","cert_policy_requires_personal_name":"NA","cert_unique_identifier_version_not_2_or_3":"NA","dh_params_missing":"NA","distribution_point_incomplete":"pass","distribution_point_missing_ldap_or_uri":"pass","dsa_improper_modulus_or_divisor_size":"NA","dsa_shorter_than_2048_bits":"NA","ec_improper_curves":"NA","eku_critical_improperly":"pass","ev_business_category_missing":"NA","ev_country_name_missing":"NA","ev_locality_name_missing":"NA","ev_organization_name_missing":"NA","ev_serial_number_missing":"NA","ev_valid_time_too_long":"NA","ext_aia_access_location_missing":"pass","ext_aia_marked_critical":"pass","ext_authority_key_identifier_critical":"pass","ext_authority_key_identifier_missing":"pass","ext_authority_key_identifier_no_key_identifier":"pass","ext_cert_policy_contains_noticeref":"pass","ext_cert_policy_disallowed_any_policy_qualifier":"pass","ext_cert_policy_duplicate":"pass","ext_cert_policy_explicit_text_ia5_string":"pass","ext_cert_policy_explicit_text_includes_control":"pass","ext_cert_policy_explicit_text_not_nfc":"pass","ext_cert_policy_explicit_text_not_utf8":"warn","ext_cert_policy_explicit_text_too_long":"pass","ext_crl_distribution_marked_critical":"pass","ext_duplicate_extension":"pass","ext_freshest_crl_marked_critical":"NA","ext_ian_critical":"NA","ext_ian_dns_not_ia5_string":"NA","ext_ian_empty_name":"NA","ext_ian_no_entries":"NA","ext_ian_rfc822_format_invalid":"NA","ext_ian_space_dns_name":"NA","ext_ian_uri_format_invalid":"NA","ext_ian_uri_host_not_fqdn_or_ip":"NA","ext_ian_uri_not_ia5":"NA","ext_ian_uri_relative":"NA","ext_key_usage_cert_sign_without_ca":"pass","ext_key_usage_not_critical":"pass","ext_key_usage_without_bits":"pass","ext_name_constraints_not_critical":"NA","ext_name_constraints_not_in_ca":"NA","ext_policy_constraints_empty":"NA","ext_policy_constraints_not_critical":"NA","ext_policy_map_any_policy":"NA","ext_policy_map_not_critical":"NA","ext_policy_map_not_in_cert_policy":"NA","ext_san_contains_reserved_ip":"pass","ext_san_critical_with_subject_dn":"pass","ext_san_directory_name_present":"pass","ext_san_dns_not_ia5_string":"pass","ext_san_dns_syntax_incorrect":"pass","ext_san_dnsname_not_fqdn":"pass","ext_san_edi_party_name_present":"pass","ext_san_empty_name":"pass","ext_san_missing":"pass","ext_san_no_entries":"pass","ext_san_not_critical_without_subject":"pass","ext_san_other_name_present":"pass","ext_san_registered_id_present":"pass","ext_san_rfc822_format_invalid":"pass","ext_san_rfc822_name_present":"pass","ext_san_space_dns_name":"pass","ext_san_uniform_resource_identifier_present":"pass","ext_san_uri_format_invalid":"pass","ext_san_uri_host_not_fqdn_or_ip":"pass","ext_san_uri_not_ia5":"pass","ext_san_uri_relative":"pass","ext_subject_directory_attr_critical":"NA","ext_subject_key_identifier_critical":"NA","ext_subject_key_identifier_missing_ca":"NA","ext_subject_key_identifier_missing_sub_cert":"warn","generalized_time_does_not_include_seconds":"NA","generalized_time_includes_fraction_seconds":"NA","generalized_time_not_in_zulu":"NA","gtld_under_consideration":"pass","ian_bare_wildcard":"NA","ian_dns_name_includes_null_char":"NA","ian_dns_name_starts_with_period":"NA","ian_iana_pub_suffix_empty":"NA","ian_wildcard_not_first":"NA","inhibit_any_policy_not_critical":"NA","invalid_certificate_version":"pass","issuer_field_empty":"pass","name_constraint_empty":"NA","name_constraint_maximum_not_absent":"NA","name_constraint_minimum_non_zero":"NA","name_constraint_on_edi_party_name":"NA","name_constraint_on_registered_id":"NA","name_constraint_on_x400":"NA","old_root_ca_rsa_mod_less_than_2048_bits":"NA","old_sub_ca_rsa_mod_less_than_1024_bits":"NA","old_sub_cert_rsa_mod_less_than_1024_bits":"NA","path_len_constraint_improperly_included":"pass","path_len_constraint_zero_or_less":"pass","public_key_type_not_allowed":"pass","root_ca_basic_constraints_path_len_constraint_field_present":"NA","root_ca_contains_cert_policy":"NA","root_ca_extended_key_usage_present":"NA","rsa_exp_negative":"pass","rsa_mod_factors_smaller_than_752":"pass","rsa_mod_less_than_2048_bits":"pass","rsa_mod_not_odd":"pass","rsa_public_exponent_not_in_range":"pass","rsa_public_exponent_not_odd":"pass","rsa_public_exponent_too_small":"pass","san_bare_wildcard":"pass","san_dns_name_includes_null_char":"pass","san_dns_name_starts_with_period":"pass","san_iana_pub_suffix_empty":"pass","san_wildcard_not_first":"pass","serial_number_longer_than_20_octets":"pass","serial_number_not_positive":"pass","sub_ca_aia_does_not_contain_issuing_ca_url":"NA","sub_ca_aia_does_not_contain_ocsp_url":"NA","sub_ca_aia_missing":"NA","sub_ca_certificate_policies_marked_critical":"NA","sub_ca_certificate_policies_missing":"NA","sub_ca_crl_distribution_points_does_not_contain_url":"NA","sub_ca_crl_distribution_points_marked_critical":"NA","sub_ca_crl_distribution_points_missing":"NA","sub_ca_eku_critical":"NA","sub_ca_name_constraints_not_critical":"NA","sub_ca_no_dns_name_contstraints":"NA","sub_ca_no_ip_name_contstraints":"NA","sub_cert_aia_does_not_contain_issuing_ca_url":"pass","sub_cert_aia_does_not_contain_ocsp_url":"pass","sub_cert_aia_missing":"pass","sub_cert_cert_policy_empty":"pass","sub_cert_certificate_policies_marked_critical":"pass","sub_cert_certificate_policies_missing":"pass","sub_cert_crl_distribution_points_does_not_contain_url":"pass","sub_cert_crl_distribution_points_marked_critical":"pass","sub_cert_eku_extra_values":"pass","sub_cert_eku_missing":"pass","sub_cert_eku_server_auth_client_auth_missing":"pass","sub_cert_key_usage_cert_sign_bit_set":"pass","sub_cert_key_usage_crl_sign_bit_set":"pass","sub_cert_or_sub_ca_using_sha1":"pass","sub_cert_sha1_expiration_too_long":"NA","subject_common_name_disallowed":"pass","subject_common_name_included":"warn","subject_common_name_not_from_san":"pass","subject_contains_noninformational_value":"pass","subject_contains_reserved_ip":"pass","subject_country_not_iso":"pass","subject_empty_without_san":"pass","subject_info_access_marked_critical":"NA","subject_locality_without_org":"pass","subject_not_dn":"pass","subject_org_without_country":"pass","subject_org_without_locality_or_province":"pass","subject_postal_without_org":"pass","subject_province_without_org":"pass","subject_street_without_org":"pass","utc_time_does_not_include_seconds":"pass","utc_time_not_in_zulu":"pass","validity_time_not_positive":"pass","wrong_time_format_pre2050":"pass"}}