### PR TITLE
Kumarde/add certpolicy output

### DIFF
--- a/zcertificate/main.go
+++ b/zcertificate/main.go
@@ -67,8 +67,7 @@ func main() {
 }
 
 func runZlint(x509Cert *x509.Certificate) (map[string]string, error) {
-	m := make(map[string]int)
-	zlintReport, err := zlint.ParsedTestHandler(x509Cert, m)
+	zlintReport, err := zlint.ParsedTestHandler(x509Cert)
 	if err != nil {
 		return nil, err
 	}
@@ -77,13 +76,12 @@ func runZlint(x509Cert *x509.Certificate) (map[string]string, error) {
 
 func appendZlintToCertificate(x509Cert *x509.Certificate, lintResult map[string]string) ([]byte, error) {
 	return json.Marshal(struct {
-		Raw []byte			`json:"raw"`
-		CertData *x509.Certificate	`json:"parsed"`
-		Zlint map[string]string 	`json:"zlint"`
-
+		Raw      []byte            `json:"raw"`
+		CertData *x509.Certificate `json:"parsed"`
+		Zlint    map[string]string `json:"zlint"`
 	}{
-		Raw: 		x509Cert.Raw,
-		CertData: 	x509Cert,
-		Zlint:          lintResult,
+		Raw:      x509Cert.Raw,
+		CertData: x509Cert,
+		Zlint:    lintResult,
 	})
 }

--- a/ztools/x509/extensions.go
+++ b/ztools/x509/extensions.go
@@ -66,10 +66,20 @@ type BasicConstraints struct {
 	MaxPathLen *int `json:"max_path_len,omitempty"`
 }
 
+type NoticeReference struct {
+	Organization		string			`json:"organization,omitempty"`
+	NoticeNumbers		NoticeNumber		`json:"notice_numbers,omitempty"`
+}
+
+type UserNoticeData struct {
+	ExplicitText		string			`json:"explicit_text,omitempty"`
+	NoticeReference		[]NoticeReference	`json:"notice_reference,omitempty"`
+}
+
 type CertificatePoliciesJSON struct {
-	PolicyIdentifier	string		`json:"policy_identifier,omitempty"`
-	CPSUri			[]string	`json:"cps,omitempty"`
-	UserNotice		[]string	`json:"user_notice,omitempty"`
+	PolicyIdentifier	string			`json:"id,omitempty"`
+	CPSUri			[]string		`json:"cps,omitempty"`
+	UserNotice		[]UserNoticeData	`json:"user_notice,omitempty"`
 }
 
 type CertificatePolicies []CertificatePoliciesJSON
@@ -91,9 +101,19 @@ func (cp *CertificatePoliciesData) MarshalJSON() ([]byte, error) {
 		for _, uri := range cp.CPSUri[idx] {
 			cpsJSON.CPSUri = append(cpsJSON.CPSUri, uri)
 		}
+
 		for _, explicit_text := range cp.ExplicitTexts[idx] {
-			cpsJSON.UserNotice = append(cpsJSON.UserNotice, explicit_text)
+			uNoticeData := UserNoticeData{}
+			uNoticeData.ExplicitText = explicit_text
+			for _, organization := range cp.NoticeRefOrganization[idx] {
+				noticeRef := NoticeReference{}
+				noticeRef.Organization = organization
+				noticeRef.NoticeNumbers = cp.NoticeRefNumbers[idx][0]
+				uNoticeData.NoticeReference = append(uNoticeData.NoticeReference, noticeRef)
+			}
+			cpsJSON.UserNotice = append(cpsJSON.UserNotice, uNoticeData)
 		}
+
 		policies = append(policies, cpsJSON)
 	}
 	return json.Marshal(policies)

--- a/ztools/x509/extensions.go
+++ b/ztools/x509/extensions.go
@@ -97,11 +97,6 @@ func (cp *CertificatePolicies) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	//qualifierIds := make([][]string, len(cp))
-	//for idx, oid := range cp.QualifierId {
-	//	qualifierIds[idx] = oid.String()
-	//}
-
 	parsed := jsonCertificatePolicies{
 		PolicyIdentifiers:     policyIdentifiers,
 		QualifierId:           qualifierIds,

--- a/ztools/x509/extensions.go
+++ b/ztools/x509/extensions.go
@@ -102,15 +102,14 @@ func (cp *CertificatePoliciesData) MarshalJSON() ([]byte, error) {
 			cpsJSON.CPSUri = append(cpsJSON.CPSUri, uri)
 		}
 
-		for _, explicit_text := range cp.ExplicitTexts[idx] {
+		for idx2, explicit_text := range cp.ExplicitTexts[idx] {
 			uNoticeData := UserNoticeData{}
 			uNoticeData.ExplicitText = explicit_text
-			for _, organization := range cp.NoticeRefOrganization[idx] {
-				noticeRef := NoticeReference{}
-				noticeRef.Organization = organization
-				noticeRef.NoticeNumbers = cp.NoticeRefNumbers[idx][0]
-				uNoticeData.NoticeReference = append(uNoticeData.NoticeReference, noticeRef)
-			}
+			noticeRef := NoticeReference{}
+			organization := cp.NoticeRefOrganization[idx][idx2]
+			noticeRef.Organization = organization
+			noticeRef.NoticeNumbers = cp.NoticeRefNumbers[idx][idx2]
+			uNoticeData.NoticeReference = append(uNoticeData.NoticeReference, noticeRef)
 			cpsJSON.UserNotice = append(cpsJSON.UserNotice, uNoticeData)
 		}
 

--- a/ztools/x509/extensions.go
+++ b/ztools/x509/extensions.go
@@ -106,10 +106,12 @@ func (cp *CertificatePoliciesData) MarshalJSON() ([]byte, error) {
 			uNoticeData := UserNoticeData{}
 			uNoticeData.ExplicitText = explicit_text
 			noticeRef := NoticeReference{}
-			organization := cp.NoticeRefOrganization[idx][idx2]
-			noticeRef.Organization = organization
-			noticeRef.NoticeNumbers = cp.NoticeRefNumbers[idx][idx2]
-			uNoticeData.NoticeReference = append(uNoticeData.NoticeReference, noticeRef)
+			if len(cp.NoticeRefOrganization[idx]) > 0 {
+				organization := cp.NoticeRefOrganization[idx][idx2]
+				noticeRef.Organization = organization
+				noticeRef.NoticeNumbers = cp.NoticeRefNumbers[idx][idx2]
+				uNoticeData.NoticeReference = append(uNoticeData.NoticeReference, noticeRef)
+			}
 			cpsJSON.UserNotice = append(cpsJSON.UserNotice, uNoticeData)
 		}
 

--- a/ztools/x509/extensions.go
+++ b/ztools/x509/extensions.go
@@ -346,8 +346,6 @@ func (kid SubjAuthKeyId) MarshalJSON() ([]byte, error) {
 
 type ExtendedKeyUsage []ExtKeyUsage
 
-//type CertificatePolicies []asn1.ObjectIdentifier
-
 // The string functions for CertValidationLevel are auto-generated via
 // `go generate <full_path_to_x509_package>` or running `go generate` in the package directory
 //go:generate stringer -type=CertValidationLevel -output=generated_certvalidationlevel_string.go
@@ -539,14 +537,6 @@ var OrganizationValidationOIDs = map[string]interface{}{
 	// TurkTrust
 	"2.16.792.3.0.3.1.1.2": nil,
 }
-
-//func (cp CertificatePolicies) MarshalJSON() ([]byte, error) {
-//	out := make([]string, len(cp))
-//	for idx, oid := range cp {
-//		out[idx] = oid.String()
-//	}
-//	return json.Marshal(out)
-//}
 
 // TODO pull out other types
 type AuthorityInfoAccess struct {

--- a/ztools/x509/x509.go
+++ b/ztools/x509/x509.go
@@ -1455,6 +1455,7 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 					for _, qualifier := range policy.Qualifiers {
 						out.QualifierId[i] = append(out.QualifierId[i], qualifier.PolicyQualifierId)
 						userNoticeOID := asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 2}
+						cpsURIOID := asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 2, 1}
 						if qualifier.PolicyQualifierId.Equal(userNoticeOID) {
 							var un userNotice
 							if _, err = asn1.Unmarshal(qualifier.Qualifier.FullBytes, &un); err != nil {
@@ -1469,6 +1470,13 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 								out.NoticeRefNumbers[i] = append(out.NoticeRefNumbers[i], un.NoticeRef.NoticeNumbers)
 								out.ParsedNoticeRefOrganization[i] = append(out.ParsedNoticeRefOrganization[i], string(un.NoticeRef.Organization.Bytes))
 							}
+						}
+						if qualifier.PolicyQualifierId.Equal(cpsURIOID) {
+							var cpsURIRaw asn1.RawValue
+							if _, err = asn1.Unmarshal(qualifier.Qualifier.FullBytes, &cpsURIRaw); err != nil {
+								return nil, err
+							}
+							out.CPSuri[i] = append(out.CPSuri[i], string(cpsURIRaw.Bytes))
 						}
 					}
 				}

--- a/ztools/x509/x509.go
+++ b/ztools/x509/x509.go
@@ -601,9 +601,13 @@ type Certificate struct {
 
 	// Certificate Policies values
 	QualifierId          [][]asn1.ObjectIdentifier
+	CPSuri               [][]string
 	ExplicitTexts        [][]asn1.RawValue
 	NoticeRefOrgnization [][]asn1.RawValue
 	NoticeRefNumbers     [][]NoticeNumber
+
+	ParsedExplicitTexts         [][]string
+	ParsedNoticeRefOrganization [][]string
 
 	// Name constraints
 	NameConstraintsCritical     bool // if true then the name constraints are marked critical.
@@ -1441,6 +1445,10 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 				out.ExplicitTexts = make([][]asn1.RawValue, len(policies))
 				out.NoticeRefOrgnization = make([][]asn1.RawValue, len(policies))
 				out.NoticeRefNumbers = make([][]NoticeNumber, len(policies))
+				out.ParsedExplicitTexts = make([][]string, len(policies))
+				out.ParsedNoticeRefOrganization = make([][]string, len(policies))
+				out.CPSuri = make([][]string, len(policies))
+
 				for i, policy := range policies {
 					out.PolicyIdentifiers[i] = policy.Policy
 					// parse optional Qualifier for zlint
@@ -1454,10 +1462,12 @@ func parseCertificate(in *certificate) (*Certificate, error) {
 							}
 							if len(un.ExplicitText.Bytes) != 0 {
 								out.ExplicitTexts[i] = append(out.ExplicitTexts[i], un.ExplicitText)
+								out.ParsedExplicitTexts[i] = append(out.ParsedExplicitTexts[i], string(un.ExplicitText.Bytes))
 							}
 							if un.NoticeRef.Organization.Bytes != nil || un.NoticeRef.NoticeNumbers != nil {
 								out.NoticeRefOrgnization[i] = append(out.NoticeRefOrgnization[i], un.NoticeRef.Organization)
 								out.NoticeRefNumbers[i] = append(out.NoticeRefNumbers[i], un.NoticeRef.NoticeNumbers)
+								out.ParsedNoticeRefOrganization[i] = append(out.ParsedNoticeRefOrganization[i], string(un.NoticeRef.Organization.Bytes))
 							}
 						}
 					}


### PR DESCRIPTION
Fixing a segmentation fault produced by an incorrect assumption about NoticeNumbers. 
