### PR TITLE
Add check in zlog to prevent crash on Windows

### DIFF
--- a/ztools/zlog/logger.go
+++ b/ztools/zlog/logger.go
@@ -97,7 +97,7 @@ func New(out io.Writer, prefix string) *Logger {
 	if ok {
 		stats, _ := file.Stat()
 		// Check to see if output is a terminal
-		if (stats.Mode() & os.ModeCharDevice) != 0 {
+		if stats != nil && (stats.Mode() & os.ModeCharDevice) != 0 {
 			useColor = true
 		}
 	}


### PR DESCRIPTION
Ensure file stats are not nil in zlog. Fixes #262.