### PR TITLE
remove log error

### DIFF
--- a/ztools/http/transport.go
+++ b/ztools/http/transport.go
@@ -1631,7 +1631,6 @@ func (pc *persistConn) readLoopPeekFailLocked(peekErr error) {
 	}
 	if n := pc.br.Buffered(); n > 0 {
 		buf, _ := pc.br.Peek(n)
-		log.Printf("Unsolicited response received on idle HTTP channel starting with %q; err=%v", buf, peekErr)
 	}
 	if peekErr == io.EOF {
 		// common case.

--- a/ztools/http/transport.go
+++ b/ztools/http/transport.go
@@ -1630,7 +1630,6 @@ func (pc *persistConn) readLoopPeekFailLocked(peekErr error) {
 		return
 	}
 	if n := pc.br.Buffered(); n > 0 {
-		buf, _ := pc.br.Peek(n)
 	}
 	if peekErr == io.EOF {
 		// common case.


### PR DESCRIPTION
This error arises when a header is incorrectly formatted or "bogus stuff". https://github.com/golang/go/issues/19895
Removing it is good because we encounter incorrectly formatted stuff quite often. 