### PR TITLE
Different output for empty responses

### DIFF
--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -301,7 +301,7 @@ func makeHTTPGrabber(config *Config, grabData *GrabData) func(string, string, st
 		}
 		grabData.HTTP.Response = resp
 
-		if err.Error() == "EOF" {
+		if err != nil && err.Error() == "EOF" {
 			return nil
 		}
 

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -301,6 +301,10 @@ func makeHTTPGrabber(config *Config, grabData *GrabData) func(string, string, st
 		}
 		grabData.HTTP.Response = resp
 
+		if err.Error() == "EOF" {
+			return nil
+		}
+
 		if err != nil {
 			config.ErrorLog.Errorf("Could not connect to remote host %s: %s", fullURL, err.Error())
 			return err

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -301,7 +301,7 @@ func makeHTTPGrabber(config *Config, grabData *GrabData) func(string, string, st
 		}
 		grabData.HTTP.Response = resp
 
-		if err != nil && err.Error() == "EOF" {
+		if err != nil && err.Error()[len(err.Error())-3:] == "EOF" {
 			return nil
 		}
 

--- a/ztools/http/client.go
+++ b/ztools/http/client.go
@@ -613,7 +613,12 @@ func (c *Client) Do(req *Request) (resp *Response, err error) {
 					timeout: true,
 				}
 			}
+			if err == io.EOF {
+				return nil, err
+			}
+
 			return nil, uerr(err)
+
 		}
 
 		var shouldRedirect bool

--- a/ztools/http/client.go
+++ b/ztools/http/client.go
@@ -618,7 +618,6 @@ func (c *Client) Do(req *Request) (resp *Response, err error) {
 			}
 
 			return nil, uerr(err)
-
 		}
 
 		var shouldRedirect bool

--- a/ztools/http/client.go
+++ b/ztools/http/client.go
@@ -613,10 +613,6 @@ func (c *Client) Do(req *Request) (resp *Response, err error) {
 					timeout: true,
 				}
 			}
-			if err == io.EOF {
-				return nil, err
-			}
-
 			return nil, uerr(err)
 		}
 


### PR DESCRIPTION
Many CDN http servers will return an empty response to an HTTP GET
with an IP host header. In the censys inferface (and from the ipv4
table) you can't distingush between these hosts and a host that has
port 80 closed.

EOF is the error returned and the IP is marked fail, this PR marks the IP as returning empty HTTP and successful IP. 

Note: the test that is currently failing is testing for the behavior that we're removing. 

Is this the type of output we would like? i.e. empty http json 
Does some other part of Censys have to be modified to get these IP's to show up?