### PR TITLE
Correct schema for XSSH DH params

### DIFF
--- a/zgrab_schema.py
+++ b/zgrab_schema.py
@@ -801,7 +801,7 @@ zgrab_xssh = Record({
                 }),
             }),
             "dh_key_exchange": SubRecord({
-                "parameters": SubRecord({
+                "params": SubRecord({
                     "prime": SubRecord({
                         "value":Binary(),
                         "length":Integer()

--- a/zgrab_schema.py
+++ b/zgrab_schema.py
@@ -802,11 +802,26 @@ zgrab_xssh = Record({
             }),
             "dh_key_exchange": SubRecord({
                 "parameters": SubRecord({
-                    "client_public":Binary(),
-                    "client_private":Binary(),
-                    "server_public":Binary(),
-                    "prime":Binary(),
-                    "generator":Binary(),
+                    "prime": SubRecord({
+                        "value":Binary(),
+                        "length":Integer()
+                    }),
+                    "generator": SubRecord({
+                        "value":Binary(),
+                        "length":Integer()
+                    }),
+                    "client_public": SubRecord({
+                        "value":Binary(),
+                        "length":Integer()
+                    }),
+                    "client_private": SubRecord({
+                        "value":Binary(),
+                        "length":Integer()
+                    }),
+                    "server_public": SubRecord({
+                        "value":Binary(),
+                        "length":Integer()
+                    }),
                 }),
                 "server_signature":xssh_signature,
                 "server_host_key":SubRecord({

--- a/ztools/xssh/kex.go
+++ b/ztools/xssh/kex.go
@@ -165,7 +165,7 @@ type dhGroup struct {
 	JsonLog       dhGroupJsonLog
 }
 type dhGroupJsonLog struct {
-	Parameters      *ztoolsKeys.DHParams  `json:"parameters,omitempty"`
+	Parameters      *ztoolsKeys.DHParams  `json:"params,omitempty"`
 	ServerSignature *JsonSignature        `json:"server_signature,omitempty"`
 	ServerHostKey   *ServerHostKeyJsonLog `json:"server_host_key,omitempty"`
 }


### PR DESCRIPTION
This matches the following parameters, from [a problematic record](https://gist.github.com/cdzombak/95244e6f5b5c0e1a5f41322309043159):

```
          "parameters": {
            "prime": {
              "length": 2048,
              "value": "///////////JD9qiIWjCNMTGYouA3BzRKQJOCIpnzHQCC76mOxObIlFKCHmONATd75UZs806QxswKwpt8l8UN0/hNW1tUcJF5IW1dmJefsb0TELppjftawv/XLb0Brft7jhr+1qJn6WunyQRfEsf5kkoZlHs5Fs9wgB8uKFjvwWY2kg2HFXTmmkWP6j9JM9fg2VdI9yjrZYcYvNWIIVSu57VKQdwlpZtZww1Tkq8mATxdGwIyhghfDKQXkYuNs474553LBgOhgObJ4Oi7Aeij7XFXfBvTFLJ3ivL9pVYFxg5lUl86pVq5RXSJhiY+gUQFXKOWoqsqmj//////////w=="
            },
            "server_public": {
              "length": 2048,
              "value": "0kz7iK25lCVUdaVm8I1itiCOd2lSYKZffrlfHFwYOLJB5P0bVrEuE7+VmXSQIcH5L4Ia/+bKQJWm4lZP5/8gB1siD/0lokrsJBz6s7vPJtCZDQCX9gsE+UU8bgQYvqn7kTfpM2w5Jc5d3uChCVsYtQ+S+ZUCXVvhW7UqETeXvOQo8TPGU60INrLMN+jyli3rqR9BxzPWxariXFWJw1/EDAkBly/vwruLHItBse+mTYqolGCFSoVWNK/wBdulpDKHSZRDf3vVHMx20tnCoDNxFl2cQ/wLI8eRjcEauXXz1xC1n+YPR2AXmvuZNT4e90qkp7kRaA9MneRuaM0vnA3VDg=="
            },
            "generator": {
              "length": 8,
              "value": "Ag=="
            },
            "client_private": {
              "length": 2048,
              "value": "ROoFoAjSQfmOjFXSAcBW6W1pvFqx437CoUPXYMjDYZtwoy1cRovKRJg3HVp+nHjzKI9LT1kZE5qhu0E/K3oQfJgbaEqIIO1rtwj8RWjSq9nJYaYIln9lIpvMgBp57Ah6wJ/I5VYsVS5sK5Q74mYdIdKPIPVLp1Hgml8X1+ORhGAEJa+NFizJn3mIp82LP47oY9usDDyPbYHxcC1pqwY8PwIVE4Qdp/u4OdpU2Q/b2nC77Ewn7z+7pmYVpcFQB34kan8OQTZ0iOjuV8lPG9JoXJ+jLyw9iJiJ7jtMeaRS8Mq1oM7ui18aw1Bf65br6kZ1RTxEP80cbVzu2rJxvM4jKQ=="
            }
          }
```

I've also changed the key name to allow us to use it in ES without trouble.