### PR TITLE
Break out XSSH key exchanges by type in JSON output 

### DIFF
--- a/zgrab_schema.py
+++ b/zgrab_schema.py
@@ -761,6 +761,11 @@ xssh_signature = SubRecord({
     "raw":Binary(),
 })
 
+golang_crypto_param = SubRecord({
+    "value":Binary(),
+    "length":Integer()
+})
+
 zgrab_xssh = Record({
     "data":SubRecord({
         "xssh":SubRecord({
@@ -800,28 +805,22 @@ zgrab_xssh = Record({
                     "compression":String(),
                 }),
             }),
-            "dh_key_exchange": SubRecord({
-                "params": SubRecord({
-                    "prime": SubRecord({
-                        "value":Binary(),
-                        "length":Integer()
-                    }),
-                    "generator": SubRecord({
-                        "value":Binary(),
-                        "length":Integer()
-                    }),
-                    "client_public": SubRecord({
-                        "value":Binary(),
-                        "length":Integer()
-                    }),
-                    "client_private": SubRecord({
-                        "value":Binary(),
-                        "length":Integer()
-                    }),
+            "key_exchange": SubRecord({
+                "curve25519sha256_params": SubRecord({
+                    "server_public": Binary(),
+                }),
+                "ecdh_params": SubRecord({
                     "server_public": SubRecord({
-                        "value":Binary(),
-                        "length":Integer()
+                        "x": golang_crypto_param,
+                        "y": golang_crypto_param,
                     }),
+                }),
+                "dh_params": SubRecord({
+                    "prime": golang_crypto_param,
+                    "generator": golang_crypto_param,
+                    "client_public": golang_crypto_param,
+                    "client_private": golang_crypto_param,
+                    "server_public": golang_crypto_param,
                 }),
                 "server_signature":xssh_signature,
                 "server_host_key":SubRecord({

--- a/zgrab_schema.py
+++ b/zgrab_schema.py
@@ -818,8 +818,6 @@ zgrab_xssh = Record({
                 "dh_params": SubRecord({
                     "prime": golang_crypto_param,
                     "generator": golang_crypto_param,
-                    "client_public": golang_crypto_param,
-                    "client_private": golang_crypto_param,
                     "server_public": golang_crypto_param,
                 }),
                 "server_signature":xssh_signature,

--- a/zgrab_schema.py
+++ b/zgrab_schema.py
@@ -806,7 +806,7 @@ zgrab_xssh = Record({
                 }),
             }),
             "key_exchange": SubRecord({
-                "ed25519sha256_params": SubRecord({
+                "curve25519_sha256_params": SubRecord({
                     "server_public": Binary(),
                 }),
                 "ecdh_params": SubRecord({

--- a/zgrab_schema.py
+++ b/zgrab_schema.py
@@ -763,7 +763,7 @@ xssh_signature = SubRecord({
 
 golang_crypto_param = SubRecord({
     "value":Binary(),
-    "length":Integer()
+    "length":Unsigned32BitInteger()
 })
 
 zgrab_xssh = Record({

--- a/zgrab_schema.py
+++ b/zgrab_schema.py
@@ -806,7 +806,7 @@ zgrab_xssh = Record({
                 }),
             }),
             "key_exchange": SubRecord({
-                "curve25519sha256_params": SubRecord({
+                "ed25519sha256_params": SubRecord({
                     "server_public": Binary(),
                 }),
                 "ecdh_params": SubRecord({

--- a/ztools/xssh/flag.go
+++ b/ztools/xssh/flag.go
@@ -147,7 +147,7 @@ func init() {
 		strings.Join(defaultCiphers, ","))
 	flag.Var(&pkgConfig.Ciphers, "xssh-ciphers", ciphersUsage)
 
-	flag.BoolVar(&pkgConfig.Verbose, "xssh-verbose", false, "Output additional information.")
+	flag.BoolVar(&pkgConfig.Verbose, "xssh-verbose", false, "Output additional information, including X/SSH client properties from the SSH handshake.")
 
 	flag.BoolVar(&pkgConfig.CollectUserAuth, "xssh-userauth", false, "Use the 'none' authentication request to see what userauth methods are allowed.")
 

--- a/ztools/xssh/kex.go
+++ b/ztools/xssh/kex.go
@@ -219,7 +219,10 @@ func (group *dhGroup) Client(c packetConn, randSource io.Reader, magics *handsha
 			break
 		}
 	}
-	group.JsonLog.Parameters.ClientPrivate = x
+
+	if pkgConfig.Verbose {
+		group.JsonLog.Parameters.ClientPrivate = x
+	}
 
 	X := new(big.Int).Exp(group.g, x, group.p)
 

--- a/ztools/xssh/kex.go
+++ b/ztools/xssh/kex.go
@@ -599,7 +599,7 @@ type curve25519sha256 struct {
 }
 
 type curve25519sha256JsonLog struct {
-	Parameters      curve25519sha256JsonLogParameters `json:"ed25519sha256_params"`
+	Parameters      curve25519sha256JsonLogParameters `json:"curve25519_sha256_params"`
 	ServerSignature *JsonSignature                    `json:"server_signature,omitempty"`
 	ServerHostKey   *ServerHostKeyJsonLog             `json:"server_host_key,omitempty"`
 }

--- a/ztools/xssh/kex.go
+++ b/ztools/xssh/kex.go
@@ -599,7 +599,7 @@ type curve25519sha256 struct {
 }
 
 type curve25519sha256JsonLog struct {
-	Parameters      curve25519sha256JsonLogParameters `json:"curve25519sha256_params"`
+	Parameters      curve25519sha256JsonLogParameters `json:"ed25519sha256_params"`
 	ServerSignature *JsonSignature                    `json:"server_signature,omitempty"`
 	ServerHostKey   *ServerHostKeyJsonLog             `json:"server_host_key,omitempty"`
 }

--- a/ztools/xssh/kex.go
+++ b/ztools/xssh/kex.go
@@ -165,7 +165,7 @@ type dhGroup struct {
 	JsonLog       dhGroupJsonLog
 }
 type dhGroupJsonLog struct {
-	Parameters      *ztoolsKeys.DHParams  `json:"params,omitempty"`
+	Parameters      *ztoolsKeys.DHParams  `json:"dh_params,omitempty"`
 	ServerSignature *JsonSignature        `json:"server_signature,omitempty"`
 	ServerHostKey   *ServerHostKeyJsonLog `json:"server_host_key,omitempty"`
 }
@@ -346,7 +346,7 @@ type ecdh struct {
 }
 
 type ecdhJsonLog struct {
-	Parameters      *ztoolsKeys.ECDHParams `json:"parameters,omitempty"`
+	Parameters      *ztoolsKeys.ECDHParams `json:"ecdh_params,omitempty"`
 	ServerSignature *JsonSignature         `json:"server_signature,omitempty"`
 	ServerHostKey   *ServerHostKeyJsonLog  `json:"server_host_key,omitempty"`
 }
@@ -599,7 +599,7 @@ type curve25519sha256 struct {
 }
 
 type curve25519sha256JsonLog struct {
-	Parameters      curve25519sha256JsonLogParameters `json:"parameters"`
+	Parameters      curve25519sha256JsonLogParameters `json:"curve25519sha256_params"`
 	ServerSignature *JsonSignature                    `json:"server_signature,omitempty"`
 	ServerHostKey   *ServerHostKeyJsonLog             `json:"server_host_key,omitempty"`
 }

--- a/ztools/xssh/kex_gex.go
+++ b/ztools/xssh/kex_gex.go
@@ -40,7 +40,7 @@ type kexDHGexRequestMsg struct {
 }
 
 type gexJsonLog struct {
-	Parameters      *ztoolsKeys.DHParams  `json:"parameters,omitempty"`
+	Parameters      *ztoolsKeys.DHParams  `json:"dh_params,omitempty"`
 	ServerSignature []byte                `json:"server_signature,omitempty"`
 	ServerHostKey   *ServerHostKeyJsonLog `json:"server_host_key,omitempty"`
 }

--- a/ztools/xssh/kex_gex.go
+++ b/ztools/xssh/kex_gex.go
@@ -41,7 +41,7 @@ type kexDHGexRequestMsg struct {
 
 type gexJsonLog struct {
 	Parameters      *ztoolsKeys.DHParams  `json:"dh_params,omitempty"`
-	ServerSignature []byte                `json:"server_signature,omitempty"`
+	ServerSignature *JsonSignature        `json:"server_signature,omitempty"`
 	ServerHostKey   *ServerHostKeyJsonLog `json:"server_host_key,omitempty"`
 }
 
@@ -150,7 +150,9 @@ func (gex *dhGEXSHA) Client(c packetConn, randSource io.Reader, magics *handshak
 
 	if gex.JsonLog != nil {
 		gex.JsonLog.Parameters.ServerPublic = kexDHGexReply.Y
-		gex.JsonLog.ServerSignature = kexDHGexReply.Signature
+		gex.JsonLog.ServerSignature = new(JsonSignature)
+		gex.JsonLog.ServerSignature.Raw = kexDHGexReply.Signature
+		gex.JsonLog.ServerSignature.Parsed, _, _ = parseSignatureBody(kexDHGexReply.Signature)
 		gex.JsonLog.ServerHostKey = LogServerHostKey(kexDHGexReply.HostKey)
 	}
 

--- a/ztools/xssh/log.go
+++ b/ztools/xssh/log.go
@@ -22,7 +22,7 @@ type HandshakeLog struct {
 	ServerKex          *kexInitMsg  `json:"server_key_exchange,omitempty"`
 	ClientKex          *kexInitMsg  `json:"client_key_exchange,omitempty"`
 	AlgorithmSelection *algorithms  `json:"algorithm_selection,omitempty"`
-	DHKeyExchange      kexAlgorithm `json:"dh_key_exchange,omitempty"`
+	DHKeyExchange      kexAlgorithm `json:"key_exchange,omitempty"`
 	UserAuth           []string     `json:"userauth,omitempty"`
 	Crypto             *kexResult   `json:"crypto,omitempty"`
 }


### PR DESCRIPTION
The principal goal of this PR is to split up the different types of key exchanges for the XSSH grabber into separate names, to allow defining a consistent schema.

There is a little more massaging & rearranging to do to make this data show up nicely in Censys, but I propose doing that in ZTag. (I should have a follow-up PR there this afternoon.)