### PR TITLE
TLSCertsOnly Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ $ zmap -p 443 --output-fields=* | ztee results.csv | zgrab --port 443 --tls --ht
 
 ## Requirements
 
-zgrab requires go version of at least 1.6. Please note that this is newer than the version included in Ubuntu 14.04 apt repository. You can install ztee from ZMap Github repository at https://github.com/zmap/zmap.
+zgrab requires go version of at least 1.8.1. Please note that this is newer than the version included in Ubuntu 14.04 apt repository. You can install ztee from ZMap Github repository at https://github.com/zmap/zmap.
 
 
 ## ZGrab as a library / dependency

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func init() {
 	flag.UintVar(&timeout, "timeout", 10, "Set connection timeout in seconds")
 	flag.BoolVar(&config.TLS, "tls", false, "Grab over TLS")
 	flag.StringVar(&tlsVersion, "tls-version", "", "Max TLS version to use (implies --tls)")
+	flag.BoolVar(&config.TLSCertsOnly, "tls-certs-only", false, "End TLS connection after receiving server certificates (implies --tls)")
 	flag.UintVar(&config.Senders, "senders", 1000, "Number of send coroutines to use")
 	flag.UintVar(&config.ConnectionsPerHost, "connections-per-host", 1, "Number of times to connect to each host (results in more output)")
 	flag.BoolVar(&config.Banners, "banners", false, "Read banner upon connection creation")

--- a/zlib/config.go
+++ b/zlib/config.go
@@ -72,7 +72,7 @@ type Config struct {
 	TLSVerbose                    bool
 	SignedCertificateTimestampExt bool
 	ExternalClientHello           []byte
-	TLSCertsOnly                   bool
+	TLSCertsOnly                  bool
 
 	// Banners and Data
 	Banners  bool

--- a/zlib/config.go
+++ b/zlib/config.go
@@ -72,6 +72,7 @@ type Config struct {
 	TLSVerbose                    bool
 	SignedCertificateTimestampExt bool
 	ExternalClientHello           []byte
+	TLSCertsOnly                   bool
 
 	// Banners and Data
 	Banners  bool

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -293,7 +293,7 @@ func (c *Conn) TLSHandshake() error {
 			c.RemoteAddr().String())
 	}
 	tlsConfig := new(tls.Config)
-	tlsConfig.TLSCertsOnly = c.tlsCertsOnly
+	tlsConfig.CertsOnly = c.tlsCertsOnly
 	tlsConfig.InsecureSkipVerify = true
 	tlsConfig.MinVersion = tls.VersionSSL30
 	tlsConfig.MaxVersion = c.maxTlsVersion

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -33,6 +33,7 @@ import (
 	"github.com/zmap/zgrab/ztools/ftp"
 	"github.com/zmap/zgrab/ztools/scada/bacnet"
 	"github.com/zmap/zgrab/ztools/util"
+
 )
 
 var smtpEndRegex = regexp.MustCompile(`(?:^\d\d\d\s.*\r\n$)|(?:^\d\d\d-[\s\S]*\r\n\d\d\d\s.*\r\n$)`)
@@ -71,6 +72,7 @@ type Conn struct {
 	gatherSessionTicket           bool
 	offerExtendedMasterSecret     bool
 	tlsVerbose                    bool
+	tlsCertsOnly                  bool
 	SignedCertificateTimestampExt bool
 
 	domain string
@@ -120,6 +122,10 @@ func (c *Conn) SetSignedCertificateTimestampExt() {
 
 func (c *Conn) SetTLSVerbose() {
 	c.tlsVerbose = true
+}
+
+func (c *Conn) SetTLSCertsOnly() {
+    c.tlsCertsOnly = true
 }
 
 // Layer in the regular conn methods
@@ -288,6 +294,7 @@ func (c *Conn) TLSHandshake() error {
 			c.RemoteAddr().String())
 	}
 	tlsConfig := new(tls.Config)
+	tlsConfig.TLSCertsOnly = c.tlsCertsOnly
 	tlsConfig.InsecureSkipVerify = true
 	tlsConfig.MinVersion = tls.VersionSSL30
 	tlsConfig.MaxVersion = c.maxTlsVersion
@@ -314,6 +321,7 @@ func (c *Conn) TLSHandshake() error {
 	if c.ExternalClientHello != nil {
 		tlsConfig.ExternalClientHello = c.ExternalClientHello
 	}
+
 
 	c.tlsConn = tls.Client(c.conn, tlsConfig)
 	c.tlsConn.SetReadDeadline(c.readDeadline)

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -329,6 +329,9 @@ func (c *Conn) TLSHandshake() error {
 	if tlsConfig.ForceSuites && err == tls.ErrUnimplementedCipher {
 		err = nil
 	}
+    if err == tls.ErrCertsOnly {
+        err = nil
+    }
 	hl := c.tlsConn.GetHandshakeLog()
 
 	if !c.tlsVerbose {

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -33,7 +33,6 @@ import (
 	"github.com/zmap/zgrab/ztools/ftp"
 	"github.com/zmap/zgrab/ztools/scada/bacnet"
 	"github.com/zmap/zgrab/ztools/util"
-
 )
 
 var smtpEndRegex = regexp.MustCompile(`(?:^\d\d\d\s.*\r\n$)|(?:^\d\d\d-[\s\S]*\r\n\d\d\d\s.*\r\n$)`)
@@ -321,7 +320,6 @@ func (c *Conn) TLSHandshake() error {
 	if c.ExternalClientHello != nil {
 		tlsConfig.ExternalClientHello = c.ExternalClientHello
 	}
-
 
 	c.tlsConn = tls.Client(c.conn, tlsConfig)
 	c.tlsConn.SetReadDeadline(c.readDeadline)

--- a/zlib/conn.go
+++ b/zlib/conn.go
@@ -124,7 +124,7 @@ func (c *Conn) SetTLSVerbose() {
 }
 
 func (c *Conn) SetTLSCertsOnly() {
-    c.tlsCertsOnly = true
+	c.tlsCertsOnly = true
 }
 
 // Layer in the regular conn methods
@@ -329,9 +329,9 @@ func (c *Conn) TLSHandshake() error {
 	if tlsConfig.ForceSuites && err == tls.ErrUnimplementedCipher {
 		err = nil
 	}
-    if err == tls.ErrCertsOnly {
-        err = nil
-    }
+	if err == tls.ErrCertsOnly {
+		err = nil
+	}
 	hl := c.tlsConn.GetHandshakeLog()
 
 	if !c.tlsVerbose {

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -420,7 +420,9 @@ func makeGrabber(config *Config) func(*Conn) error {
 		if config.TLSVerbose {
 			c.SetTLSVerbose()
 		}
-
+		if config.TLSCertsOnly {
+			c.SetTLSCertsOnly()
+		}
 		if config.TLS {
 			if err := c.TLSHandshake(); err != nil {
 				c.erroredComponent = "tls"


### PR DESCRIPTION
This PR is connected to new functionality proposed for zcryto: https://github.com/zmap/zcrypto/pull/100

Scanning goes faster if you don't continue the TLS handshake after getting the certs, and furthermore if you don't parse the TLS Certs on the same host that scans them.  With this option you can scan more hosts faster (by moving on before completing the TLS handshake) and you can collect certificates, diff them against a store of parsed certificates, and only parse the new ones.