### PR TITLE
Add Accept HTTP header

### DIFF
--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -295,8 +295,6 @@ func makeHTTPGrabber(config *Config, grabData *GrabData) func(string, string, st
 			fullURL = "http://" + urlHost + endpoint
 		}
 
-		var resp *http.Response
-
 		u, err := url.Parse(fullURL)
 		if err != nil {
 			return err
@@ -314,7 +312,10 @@ func makeHTTPGrabber(config *Config, grabData *GrabData) func(string, string, st
 			}
 			httpHost = hostWithoutPort
 		}
+
 		var req *http.Request
+		var resp *http.Response
+
 		switch config.HTTP.Method {
 		case "GET":
 			req, err = http.NewRequestWithHost("GET", fullURL, httpHost, nil)

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -314,14 +314,18 @@ func makeHTTPGrabber(config *Config, grabData *GrabData) func(string, string, st
 			}
 			httpHost = hostWithoutPort
 		}
-
+		var req *http.Request
 		switch config.HTTP.Method {
 		case "GET":
-			resp, err = client.GetWithHost(fullURL, httpHost)
+			req, err = http.NewRequestWithHost("GET", fullURL, httpHost, nil)
 		case "HEAD":
-			resp, err = client.HeadWithHost(fullURL, httpHost)
+			req, err = http.NewRequestWithHost("HEAD", fullURL, httpHost, nil)
 		default:
 			zlog.Fatalf("Bad HTTP Method: %s. Valid options are: GET, HEAD.", config.HTTP.Method)
+		}
+		if err == nil {
+			req.Header.Set("Accept", "*/*")
+			resp, err = client.Do(req)
 		}
 		if resp != nil && resp.Body != nil {
 			defer resp.Body.Close()

--- a/zlib/grabber_test.go
+++ b/zlib/grabber_test.go
@@ -30,8 +30,8 @@ func TestHTTP(t *testing.T) {
 		if r.Protocol.Name != "HTTP/1.1" {
 			t.Errorf("Wrong Protocol - expected: %s, got: %s", "HTTP/1.1", r.Protocol.Name)
 		}
-		if len(r.Header) != 2 || r.Header.Get("User-Agent") != "test UA" || r.Header.Get("Accept-Encoding") != "gzip" {
-			t.Errorf("Wrong headers: Expected User-Agent and Accept-Encoding, Got %s", r.Header)
+		if len(r.Header) != 3 || r.Header.Get("User-Agent") != "test UA" || r.Header.Get("Accept-Encoding") != "gzip" || r.Header.Get("Accept") != "*/*" {
+			t.Errorf("Wrong headers: Expected User-Agent, Accept, and Accept-Encoding, Got %s", r.Header)
 		}
 		fmt.Fprintf(w, TEST_SERVER_BODY)
 	}))


### PR DESCRIPTION
For `http` zgrab requests, add an `Accept: */*` header (addresses issue #301)