### PR TITLE
zgrab: log target address/port on panic

### DIFF
--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"net"
 	"net/url"
-	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -637,7 +636,7 @@ func GrabBanner(config *Config, target *GrabTarget) *Grab {
 			if target.Addr != nil {
 				addr = target.Addr.String()
 			}
-			config.ErrorLog.Errorf("Panic when scanning addr = %s / domain = %s, port %d", addr, target.Domain, config.Port))
+			config.ErrorLog.Errorf("Panic when scanning addr = %s / domain = %s, port %d", addr, target.Domain, config.Port)
 			// Bubble out original error (with original stack) in lieu of explicitly logging the stack / error
 			panic(e)
 		}

--- a/zlib/grabber.go
+++ b/zlib/grabber.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -630,6 +631,18 @@ func makeXSSHGrabber(gblConfig *Config, grabData GrabData) func(string) error {
 }
 
 func GrabBanner(config *Config, target *GrabTarget) *Grab {
+	defer func() {
+		if e := recover(); e != nil {
+			addr := "<not set>"
+			if target.Addr != nil {
+				addr = target.Addr.String()
+			}
+			config.ErrorLog.Errorf("Panic when scanning addr = %s / domain = %s, port %d", addr, target.Domain, config.Port))
+			// Bubble out original error (with original stack) in lieu of explicitly logging the stack / error
+			panic(e)
+		}
+	}()
+
 	if config.XSSH.XSSH {
 		t := time.Now()
 


### PR DESCRIPTION
If there is a `panic()` while scanning a target in GrabBanner, trap it and log the target to the standard logger at the ERROR level, before re-throwing the panic.

## How to Test

There is no place place that intentionally panics, so I have been testing by adding a panic() call to e.g. `Scan@modules/ftp.go`.

## Notes & Caveats

This arose from debugging https://ichnaea.eecs.umich.edu/admin/tasks/a47e2ae2-4f47-4ae4-86da-b8cc3a85a5c9 -- since the code panicked, the IP address did not get written to the output. We don't log the IP in non-panic cases since in those cases, the IP address should be available in the output.

## Issue Tracking

Re https://trello.com/c/CcL2qo60/1191-zgrab-https-scan-segfault, which was fixed by https://github.com/zmap/zcrypto/pull/107.
