### PR TITLE
Catch nil header `exclude` map

### DIFF
--- a/ztools/http/header.go
+++ b/ztools/http/header.go
@@ -188,7 +188,7 @@ func (h Header) sortedKeyValues(exclude map[string]bool) (kvs []keyValues, hs *h
 	}
 	kvs = hs.kvs[:0]
 	for k, vv := range h {
-		if !exclude[k] {
+		if exclude != nil && !exclude[k] {
 			kvs = append(kvs, keyValues{k, vv})
 		}
 	}


### PR DESCRIPTION
`exclude` can be nil in a few cases (e.g. explicitly in header.Write(), but also in some cases of chunkWriter.writeHeader).
