### PR TITLE
ztools/processing: marshal errors should not abort scans

### DIFF
--- a/ztools/processing/input.go
+++ b/ztools/processing/input.go
@@ -71,7 +71,9 @@ func Process(in Decoder, out io.Writer, w Worker, m Marshaler, workers uint) {
 					result := handler(obj)
 					enc, err := m.Marshal(result)
 					if err != nil {
-						panic(err.Error())
+						// Don't let an unexpected marshaling error abort the rest of the scan, but still log the error.
+						zlog.Errorf("Error marshaling result %#v from object %#v: %s", result, obj, err.Error())
+						continue
 					}
 					outputQueue <- enc
 				}


### PR DESCRIPTION
If it hits a host that returns syntactically-valid response but violates the `json.Marshal` checks, a panic is currently raised, stopping the rest of the scan.

This patch will instead log the error.